### PR TITLE
Fix extra slash in update address

### DIFF
--- a/Shared/Constants.h
+++ b/Shared/Constants.h
@@ -67,7 +67,7 @@ typedef enum {
 
 #define kMFWebsiteAddress  @"https://noah-nuebling.github.io/mac-mouse-fix-website" //@"https://mousefix.org"
 
-#define kMFUpdateFeedRepoAddressRaw @"https://raw.githubusercontent.com/noah-nuebling/mac-mouse-fix/update-feed/"
+#define kMFUpdateFeedRepoAddressRaw @"https://raw.githubusercontent.com/noah-nuebling/mac-mouse-fix/update-feed"
 
 // Sparkle
 


### PR DESCRIPTION
There's an extra slash in the app update address, as you can see from below. While updating currently still works (GitHub redirects), it's better to just have the correct address.

https://github.com/noah-nuebling/mac-mouse-fix/blob/8064ff9aca790efb280b1db0d92f81edeaf1c49c/Shared/Constants.h#L70

https://github.com/noah-nuebling/mac-mouse-fix/blob/8064ff9aca790efb280b1db0d92f81edeaf1c49c/App/Update/SparkleUpdaterController.m#L19-L25

