### PR TITLE
 Reset _mouseIsOverSelf after mouseUp in Hyperlink.m

### DIFF
--- a/Shared/UI/Hyperlink.m
+++ b/Shared/UI/Hyperlink.m
@@ -182,6 +182,7 @@ IB_DESIGNABLE
         [self reactToClick];
     }
     _mouseDownOverSelf = NO;
+    _mouseIsOverSelf = NO;
 }
 - (void)reactToClick {
     


### PR DESCRIPTION
`_mouseIsOverSelf` remains true after window loses focus, which causes this.

https://user-images.githubusercontent.com/107956274/191377815-fa4ebe12-7e9e-40a6-8623-34b1a089a10c.mp4
