### PR TITLE
Add directional drag gesture for media and volume control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ xcuserdata/
 # !Mouse Fix.xcodeproj/xcuserdata/Noah.xcuserdatad/
 # !Mouse Fix.xcodeproj/xcuserdata/Noah.xcuserdatad/xcschemes/*
 # Mouse Fix.xcodeproj/xcuserdata/Noah.xcuserdatad/xcdebugger/*
+
+# CodeQL artifacts
+_codeql_detected_source_root

--- a/App/UI/Main/Tabs/ButtonTab/RemapTable/RemapTableTranslator.m
+++ b/App/UI/Main/Tabs/ButtonTab/RemapTable/RemapTableTranslator.m
@@ -124,6 +124,13 @@ static NSArray *getDragEffectsTable() {
                   kMFModifiedDragDictKeyType: kMFModifiedDragTypeTwoFingerSwipe,
             }
         },
+        @{
+            @"ui": MFLocalizedString(@"drag-effect.media-control", @""),
+            @"tool": MFLocalizedString(@"drag-effect.media-control.hint", @"") ,
+            @"dict": @{
+                  kMFModifiedDragDictKeyType: kMFModifiedDragTypeMediaControl,
+            }
+        },
 //        separatorEffectsTableEntry(),
 //        @{
 ////          @"ui": [NSString stringWithFormat:@"%@ Click and Drag", [UIStrings getButtonString:3]],

--- a/Helper/Core/Drag/MediaControl/ModifiedDragOutputMediaControl.h
+++ b/Helper/Core/Drag/MediaControl/ModifiedDragOutputMediaControl.h
@@ -1,0 +1,19 @@
+//
+// --------------------------------------------------------------------------
+// ModifiedDragOutputMediaControl.h
+// Created for Mac Mouse Fix (https://github.com/noah-nuebling/mac-mouse-fix)
+// Created by Noah Nuebling in 2026
+// Licensed under the MMF License (https://github.com/noah-nuebling/mac-mouse-fix/blob/master/License)
+// --------------------------------------------------------------------------
+//
+
+#import <Foundation/Foundation.h>
+#import "ModifiedDrag.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ModifiedDragOutputMediaControl : NSObject<ModifiedDragOutputPlugin>
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Helper/Core/Drag/MediaControl/ModifiedDragOutputMediaControl.m
+++ b/Helper/Core/Drag/MediaControl/ModifiedDragOutputMediaControl.m
@@ -1,0 +1,168 @@
+//
+// --------------------------------------------------------------------------
+// ModifiedDragOutputMediaControl.m
+// Created for Mac Mouse Fix (https://github.com/noah-nuebling/mac-mouse-fix)
+// Created by Noah Nuebling in 2026
+// Licensed under the MMF License (https://github.com/noah-nuebling/mac-mouse-fix/blob/master/License)
+// --------------------------------------------------------------------------
+//
+
+#import "ModifiedDragOutputMediaControl.h"
+#import "ModificationUtility.h"
+#import "SharedUtility.h"
+#import "HelperUtility.h"
+#import "Constants.h"
+#import <Cocoa/Cocoa.h>
+
+@implementation ModifiedDragOutputMediaControl
+
+/// Vars
+
+static ModifiedDragState *_drag;
+static double _cumulativeX;
+static double _cumulativeY;
+static BOOL _trackEventFired;  // Tracks whether media track event (left/right) was fired
+static double _lastVolumeEventY; // Track position of last volume event
+
+/// Lock the gesture to either horizontal (track) or vertical (volume) mode
+typedef enum {
+    kGestureModeUndetermined,
+    kGestureModeHorizontal,  // Locked to track control
+    kGestureModeVertical     // Locked to volume control
+} GestureMode;
+static GestureMode _gestureMode;
+
+/// Threshold for triggering a media control event (in pixels)
+static const double kMediaControlThreshold = 50.0;
+
+/// Threshold for triggering additional volume events (in pixels)
+static const double kVolumeRepeatThreshold = 30.0;
+
+/// Interface
+
++ (void)initializeWithDragState:(ModifiedDragState *)dragStateRef {
+    _drag = dragStateRef;
+    _cumulativeX = 0.0;
+    _cumulativeY = 0.0;
+    _trackEventFired = NO;
+    _lastVolumeEventY = 0.0;
+    _gestureMode = kGestureModeUndetermined;
+}
+
++ (void)handleBecameInUse {
+    // Reset state when drag becomes active
+    _cumulativeX = 0.0;
+    _cumulativeY = 0.0;
+    _trackEventFired = NO;
+    _lastVolumeEventY = 0.0;
+    _gestureMode = kGestureModeUndetermined;
+}
+
++ (void)handleMouseInputWhileInUseWithDeltaX:(double)deltaX deltaY:(double)deltaY event:(CGEventRef)event {
+    
+    // Accumulate movement
+    _cumulativeX += deltaX;
+    _cumulativeY += deltaY;
+    
+    // Check if threshold is crossed
+    double absX = fabs(_cumulativeX);
+    double absY = fabs(_cumulativeY);
+    
+    if (absX < kMediaControlThreshold && absY < kMediaControlThreshold) {
+        return;
+    }
+    
+    // Determine and lock gesture mode on first threshold crossing
+    if (_gestureMode == kGestureModeUndetermined) {
+        // Lock to whichever direction is dominant when threshold is first crossed
+        _gestureMode = (absX > absY) ? kGestureModeHorizontal : kGestureModeVertical;
+    }
+    
+    // Execute action based on locked gesture mode
+    MFSystemDefinedEventType eventType;
+    
+    if (_gestureMode == kGestureModeHorizontal) {
+        // Horizontal gesture - Media track control (one-shot)
+        // Only fire event once per drag gesture for track changes
+        if (_trackEventFired) {
+            return;
+        }
+        
+        if (_cumulativeX > 0) {
+            eventType = kMFSystemEventTypeMediaForward; // Right = Next track
+        } else {
+            eventType = kMFSystemEventTypeMediaBack;    // Left = Previous track
+        }
+        
+        // Post the system event
+        [self postSystemDefinedEvent:eventType withModifierFlags:0];
+        _trackEventFired = YES;
+        
+    } else if (_gestureMode == kGestureModeVertical) {
+        // Vertical gesture - Volume control (continuous)
+        // Allow repeated volume events as user continues dragging
+        
+        // Calculate distance traveled since last volume event
+        double distanceSinceLastEvent = fabs(_cumulativeY - _lastVolumeEventY);
+        
+        if (distanceSinceLastEvent >= kVolumeRepeatThreshold) {
+            if (_cumulativeY > 0) {
+                eventType = kMFSystemEventTypeVolumeDown;   // Down = Volume down (positive Y is down)
+            } else {
+                eventType = kMFSystemEventTypeVolumeUp;     // Up = Volume up (negative Y is up)
+            }
+            
+            // Post the system event
+            [self postSystemDefinedEvent:eventType withModifierFlags:0];
+            
+            // Update last event position
+            _lastVolumeEventY = _cumulativeY;
+        }
+    }
+}
+
++ (void)handleDeactivationWhileInUseWithCancel:(BOOL)cancelation {
+    // Reset state when drag ends
+    _cumulativeX = 0.0;
+    _cumulativeY = 0.0;
+    _trackEventFired = NO;
+    _lastVolumeEventY = 0.0;
+    _gestureMode = kGestureModeUndetermined;
+}
+
++ (void)suspend {
+    // No special handling needed for suspend
+}
+
++ (void)unsuspend {
+    // No special handling needed for unsuspend
+}
+
+#pragma mark - Helper Methods
+
++ (void)postSystemDefinedEvent:(MFSystemDefinedEventType)type withModifierFlags:(NSEventModifierFlags)modifierFlags {
+    /// Post a system defined event for media control or volume control
+    /// Based on postSystemDefinedEvent from Actions.m
+    
+    CGEventTapLocation tapLoc = kCGSessionEventTap;
+    NSPoint loc = NSEvent.mouseLocation;
+    
+    NSInteger data = 0;
+    data = data | kMFSystemDefinedEventBase;
+    data = data | (type << 16);
+    
+    NSInteger downData = data;
+    NSInteger upData = data | kMFSystemDefinedEventPressedMask;
+    
+    /// Post key down
+    NSTimeInterval ts = [ModificationUtility nsTimeStamp];
+    NSEvent *e = [NSEvent otherEventWithType:14 location:loc modifierFlags:modifierFlags timestamp:ts windowNumber:-1 context:nil subtype:8 data1:downData data2:-1];
+    CGEventPost(tapLoc, e.CGEvent);
+    
+    /// Post key up
+    ts = [ModificationUtility nsTimeStamp];
+    e = [NSEvent otherEventWithType:14 location:loc modifierFlags:modifierFlags timestamp:ts windowNumber:-1 context:nil subtype:8 data1:upData data2:-1];
+    CGEventPost(tapLoc, e.CGEvent);
+}
+
+@end

--- a/Helper/Core/Drag/ModifiedDrag.m
+++ b/Helper/Core/Drag/ModifiedDrag.m
@@ -31,6 +31,7 @@
 #import "ModifiedDragOutputTwoFingerSwipe.h"
 #import "ModifiedDragOutputFakeDrag.h"
 #import "ModifiedDragOutputAddMode.h"
+#import "ModifiedDragOutputMediaControl.h"
 
 #import "GlobalEventTapThread.h"
 
@@ -176,6 +177,8 @@ static ModifiedDragState _drag;
             p = (id<ModifiedDragOutputPlugin>)ModifiedDragOutputFakeDrag.class;
         } else if ([type isEqualToString:kMFModifiedDragTypeAddModeFeedback]) {
             p = (id<ModifiedDragOutputPlugin>)ModifiedDragOutputAddMode.class;
+        } else if ([type isEqualToString:kMFModifiedDragTypeMediaControl]) {
+            p = (id<ModifiedDragOutputPlugin>)ModifiedDragOutputMediaControl.class;
         } else {
             assert(false);
         }

--- a/Localization/Localizable.xcstrings
+++ b/Localization/Localizable.xcstrings
@@ -4480,6 +4480,28 @@
         }
       }
     },
+    "drag-effect.media-control" : {
+      "comment" : "",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Media Control"
+          }
+        }
+      }
+    },
+    "drag-effect.media-control.hint" : {
+      "comment" : "",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Control media playback and volume by dragging your mouse:\n - Left to skip to previous track\n - Right to skip to next track\n - Up to increase volume\n - Down to decrease volume"
+          }
+        }
+      }
+    },
     "effect.app-expose" : {
       "comment" : "Note: Apple refers to this feature by different names like 'Application Windows' or 'App Exposé'. In English I chose the same name that is used at\nSystem Settings > Keyboard > Keyboard Shortcuts > Mission Control > Application Windows. (Under macOS 26 Tahoe)\n\nFurther details: Under macOS Sonoma, this feature is called 'App Exposé' in Trackpad settings, but 'Application Windows' in Keyboard Shortcut settings, and other places I found. I also saw 'Show all windows of the front app' and 'Show all open windows for the current app' in Apple's documentation. I went with 'Application Windows' because it's short and 'App Exposé' felt a bit outdated. (Exposé was the predecessor to Mission Control, and the term mostly doesn't occur anymore in macOS now.)",
       "localizations" : {

--- a/Mouse Fix.xcodeproj/project.pbxproj
+++ b/Mouse Fix.xcodeproj/project.pbxproj
@@ -339,6 +339,7 @@
 		4FF0255127B0033000923107 /* ModifiedDragOutputTwoFingerSwipe.m in Sources */ = {isa = PBXBuildFile; fileRef = 4FF0255027B0033000923107 /* ModifiedDragOutputTwoFingerSwipe.m */; };
 		4FF0255427B007FC00923107 /* ModifiedDragOutputFakeDrag.m in Sources */ = {isa = PBXBuildFile; fileRef = 4FF0255327B007FC00923107 /* ModifiedDragOutputFakeDrag.m */; };
 		4FF0255727B0091700923107 /* ModifiedDragOutputAddMode.m in Sources */ = {isa = PBXBuildFile; fileRef = 4FF0255627B0091700923107 /* ModifiedDragOutputAddMode.m */; };
+		8BBBB086F30314C0735B7FCD /* ModifiedDragOutputMediaControl.m in Sources */ = {isa = PBXBuildFile; fileRef = 210E75CBA1280BFC1F08104D /* ModifiedDragOutputMediaControl.m */; };
 		4FF0255F27B013A100923107 /* PointerFreeze.m in Sources */ = {isa = PBXBuildFile; fileRef = 4FF0255E27B013A100923107 /* PointerFreeze.m */; };
 		4FF0BD4B266A8B7E003935EA /* Bezier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FF0BD4A266A8B7E003935EA /* Bezier.swift */; };
 		4FF0BD51266AC10C003935EA /* Math.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FF0BD50266AC10C003935EA /* Math.swift */; };
@@ -2436,6 +2437,8 @@
 		4FF0255327B007FC00923107 /* ModifiedDragOutputFakeDrag.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ModifiedDragOutputFakeDrag.m; sourceTree = "<group>"; };
 		4FF0255527B0091700923107 /* ModifiedDragOutputAddMode.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ModifiedDragOutputAddMode.h; sourceTree = "<group>"; };
 		4FF0255627B0091700923107 /* ModifiedDragOutputAddMode.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ModifiedDragOutputAddMode.m; sourceTree = "<group>"; };
+		44C3DF1C10F0CFB60C8C19B1 /* ModifiedDragOutputMediaControl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ModifiedDragOutputMediaControl.h; sourceTree = "<group>"; };
+		210E75CBA1280BFC1F08104D /* ModifiedDragOutputMediaControl.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ModifiedDragOutputMediaControl.m; sourceTree = "<group>"; };
 		4FF0255D27B013A100923107 /* PointerFreeze.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PointerFreeze.h; sourceTree = "<group>"; };
 		4FF0255E27B013A100923107 /* PointerFreeze.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PointerFreeze.m; sourceTree = "<group>"; };
 		4FF0BD4A266A8B7E003935EA /* Bezier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bezier.swift; sourceTree = "<group>"; };
@@ -7416,6 +7419,15 @@
 			path = AddMode;
 			sourceTree = "<group>";
 		};
+		759217989439E42FAA8177AA /* MediaControl */ = {
+			isa = PBXGroup;
+			children = (
+				44C3DF1C10F0CFB60C8C19B1 /* ModifiedDragOutputMediaControl.h */,
+				210E75CBA1280BFC1F08104D /* ModifiedDragOutputMediaControl.m */,
+			);
+			path = MediaControl;
+			sourceTree = "<group>";
+		};
 		4FF6652B25F2C7B000689B77 /* Shared */ = {
 			isa = PBXGroup;
 			children = (
@@ -7718,6 +7730,7 @@
 				4FF0255927B00FA400923107 /* TwoFingerSwipe */,
 				4FF0255A27B00FAF00923107 /* FakeDrag */,
 				4FF0255B27B00FBA00923107 /* AddMode */,
+				759217989439E42FAA8177AA /* MediaControl */,
 			);
 			path = Drag;
 			sourceTree = "<group>";

--- a/Shared/Constants.h
+++ b/Shared/Constants.h
@@ -145,6 +145,7 @@ typedef NSString*                                                       MFString
 #define kMFModifiedDragTypeThreeFingerSwipe                             @"threeFingerSwipe"
 #define kMFModifiedDragTypeFakeDrag                                     @"fakeDrag"
 #define kMFModifiedDragTypeAddModeFeedback                              @"addModeDrag"
+#define kMFModifiedDragTypeMediaControl                                 @"mediaControl"
 // Variant keys
 #define kMFModifiedDragDictKeyFakeDragVariantButtonNumber               @"buttonNumber"
 


### PR DESCRIPTION
This is my attempt at #806 using github copilot. 

Full transparency: I am not a MacOS dev and used Github Copilot to generate this PR. From what I can tell, this should work as intended. The code generated reads well and the logic matches what I would expect, logic-wise. 

The log of how I got here can be found here: https://github.com/BenMcH/mac-mouse-fix/pull/1

If this work is of interest, please let me know how I can support refining this and getting it into the project