### PR TITLE
Add GitHub Action to build a DMG from upstream release assets

### DIFF
--- a/.github/workflows/build-dmg.yml
+++ b/.github/workflows/build-dmg.yml
@@ -7,9 +7,12 @@ on:
         description: Upstream release tag to repackage as DMG
         required: true
         default: "3.0.8"
+  release:
+    types:
+      - published
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   build-dmg:
@@ -39,7 +42,12 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           mkdir -p "$ZIP_DOWNLOAD_DIR"
-          gh release download "${{ inputs.release_tag }}" \
+          RELEASE_TAG="${{ inputs.release_tag }}"
+          if [ -z "$RELEASE_TAG" ]; then
+            RELEASE_TAG="${{ github.event.release.tag_name }}"
+          fi
+          test -n "$RELEASE_TAG"
+          gh release download "$RELEASE_TAG" \
             --repo "$UPSTREAM_REPO" \
             --pattern "$UPSTREAM_ASSET_NAME" \
             --dir "$ZIP_DOWNLOAD_DIR"
@@ -71,6 +79,20 @@ jobs:
       - name: Upload DMG artifact
         uses: actions/upload-artifact@v4
         with:
-          name: mac-mouse-fix-dmg-${{ inputs.release_tag }}
+          name: mac-mouse-fix-dmg-${{ inputs.release_tag || github.event.release.tag_name }}
           path: ${{ github.workspace }}/build/dmg/*.dmg
           if-no-files-found: error
+
+      - name: Upload DMG to release assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          RELEASE_TAG="${{ inputs.release_tag }}"
+          if [ -z "$RELEASE_TAG" ]; then
+            RELEASE_TAG="${{ github.event.release.tag_name }}"
+          fi
+          test -n "$RELEASE_TAG"
+          gh release upload "$RELEASE_TAG" \
+            "$DMG_OUTPUT_DIR"/*.dmg \
+            --repo "$GITHUB_REPOSITORY" \
+            --clobber

--- a/.github/workflows/build-dmg.yml
+++ b/.github/workflows/build-dmg.yml
@@ -1,10 +1,12 @@
-name: Build DMG
+name: Build DMG From Upstream Release
 
 on:
   workflow_dispatch:
-  push:
-    tags:
-      - "v*"
+    inputs:
+      release_tag:
+        description: Upstream release tag to repackage as DMG
+        required: true
+        default: "3.0.8"
 
 permissions:
   contents: read
@@ -13,46 +15,62 @@ jobs:
   build-dmg:
     runs-on: macos-15
 
+    env:
+      UPSTREAM_REPO: noah-nuebling/mac-mouse-fix
+      UPSTREAM_ASSET_NAME: MacMouseFixApp.zip
+      ZIP_DOWNLOAD_DIR: ${{ github.workspace }}/build/upstream
+      EXTRACT_DIR: ${{ github.workspace }}/build/extracted
+      DMG_OUTPUT_DIR: ${{ github.workspace }}/build/dmg
+
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: "20"
+          node-version: "24"
 
       - name: Install create-dmg
         run: npm install --global create-dmg
 
-      - name: Build Mac Mouse Fix.app
+      - name: Download upstream release asset
         env:
-          DERIVED_DATA_PATH: ${{ github.workspace }}/build/DerivedData
-          SOURCE_PACKAGES_PATH: ${{ github.workspace }}/build/SourcePackages
+          GH_TOKEN: ${{ github.token }}
         run: |
-          xcodebuild \
-            -project "Mouse Fix.xcodeproj" \
-            -scheme "App - Release" \
-            -configuration Release \
-            -derivedDataPath "$DERIVED_DATA_PATH" \
-            -clonedSourcePackagesDirPath "$SOURCE_PACKAGES_PATH" \
-            CODE_SIGNING_ALLOWED=NO \
-            CODE_SIGNING_REQUIRED=NO \
-            CODE_SIGN_IDENTITY="" \
-            build
+          mkdir -p "$ZIP_DOWNLOAD_DIR"
+          gh release download "${{ inputs.release_tag }}" \
+            --repo "$UPSTREAM_REPO" \
+            --pattern "$UPSTREAM_ASSET_NAME" \
+            --dir "$ZIP_DOWNLOAD_DIR"
+          test -f "$ZIP_DOWNLOAD_DIR/$UPSTREAM_ASSET_NAME"
+
+      - name: Extract upstream app
+        env:
+          APP_PATH: ${{ github.workspace }}/build/extracted/Mac Mouse Fix.app
+        run: |
+          rm -rf "$EXTRACT_DIR"
+          mkdir -p "$EXTRACT_DIR"
+          ditto -x -k "$ZIP_DOWNLOAD_DIR/$UPSTREAM_ASSET_NAME" "$EXTRACT_DIR"
+          test -d "$APP_PATH"
+
+      - name: Verify upstream app signature
+        env:
+          APP_PATH: ${{ github.workspace }}/build/extracted/Mac Mouse Fix.app
+        run: |
+          codesign --verify --deep --strict "$APP_PATH"
+          spctl -a -vv "$APP_PATH"
 
       - name: Create DMG
         env:
-          APP_PATH: ${{ github.workspace }}/build/DerivedData/Build/Products/Release/Mac Mouse Fix.app
-          DMG_OUTPUT_DIR: ${{ github.workspace }}/build/dmg
+          APP_PATH: ${{ github.workspace }}/build/extracted/Mac Mouse Fix.app
         run: |
-          test -d "$APP_PATH"
           mkdir -p "$DMG_OUTPUT_DIR"
           create-dmg --overwrite --no-code-sign "$APP_PATH" "$DMG_OUTPUT_DIR"
 
       - name: Upload DMG artifact
         uses: actions/upload-artifact@v4
         with:
-          name: mac-mouse-fix-dmg
+          name: mac-mouse-fix-dmg-${{ inputs.release_tag }}
           path: ${{ github.workspace }}/build/dmg/*.dmg
           if-no-files-found: error

--- a/.github/workflows/build-dmg.yml
+++ b/.github/workflows/build-dmg.yml
@@ -1,0 +1,58 @@
+name: Build DMG
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+jobs:
+  build-dmg:
+    runs-on: macos-15
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install create-dmg
+        run: npm install --global create-dmg
+
+      - name: Build Mac Mouse Fix.app
+        env:
+          DERIVED_DATA_PATH: ${{ github.workspace }}/build/DerivedData
+          SOURCE_PACKAGES_PATH: ${{ github.workspace }}/build/SourcePackages
+        run: |
+          xcodebuild \
+            -project "Mouse Fix.xcodeproj" \
+            -scheme "App - Release" \
+            -configuration Release \
+            -derivedDataPath "$DERIVED_DATA_PATH" \
+            -clonedSourcePackagesDirPath "$SOURCE_PACKAGES_PATH" \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGN_IDENTITY="" \
+            build
+
+      - name: Create DMG
+        env:
+          APP_PATH: ${{ github.workspace }}/build/DerivedData/Build/Products/Release/Mac Mouse Fix.app
+          DMG_OUTPUT_DIR: ${{ github.workspace }}/build/dmg
+        run: |
+          test -d "$APP_PATH"
+          mkdir -p "$DMG_OUTPUT_DIR"
+          create-dmg --overwrite --no-code-sign "$APP_PATH" "$DMG_OUTPUT_DIR"
+
+      - name: Upload DMG artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: mac-mouse-fix-dmg
+          path: ${{ github.workspace }}/build/dmg/*.dmg
+          if-no-files-found: error


### PR DESCRIPTION
Summary
This adds a GitHub Actions workflow that creates a .dmg from the already-published upstream MacMouseFixApp.zip release asset, instead of rebuilding the app from source.

Why
The upstream project already publishes signed and notarized app bundles as release assets and uses those for distribution/update flows. Repackaging the published .app into a .dmg is more reliable than trying to compile master in CI, and stays closer to the actual release artifacts users receive.

What this workflow does
Triggers on:
release.published
manual workflow_dispatch
Downloads MacMouseFixApp.zip from noah-nuebling/mac-mouse-fix
Extracts Mac Mouse Fix.app
Verifies the extracted app signature/notarization
Uses [create-dmg](https://github.com/sindresorhus/create-dmg) to generate a .dmg
Uploads the generated DMG as:
an Actions artifact
a release asset
Notes
This workflow does not rebuild the app from source.
It repackages the already-published release asset, which helps avoid CI build issues on GitHub-hosted runners while preserving the upstream signing/notarization on the app bundle itself.
Manual dispatch accepts a release_tag input for testing older releases.
Testing
Tested in my fork by running the workflow against release 3.0.8:

upstream MacMouseFixApp.zip downloaded successfully
extracted .app passed codesign / spctl verification
DMG was created successfully
artifact upload succeeded