### PR TITLE
Add momentum arrest: trackpad-like scroll stop

### DIFF
--- a/App/UI/Main/Tabs/ScrollTabController.swift
+++ b/App/UI/Main/Tabs/ScrollTabController.swift
@@ -24,6 +24,7 @@ class ScrollTabController: NSViewController {
     var zoomMod = ConfigValue<UInt>(configPath: "Scroll.modifiers.zoom")
     var swiftMod = ConfigValue<UInt>(configPath: "Scroll.modifiers.swift")
     var preciseMod = ConfigValue<UInt>(configPath: "Scroll.modifiers.precise")
+    var momentumArrestMode = ConfigValue<String>(configPath: "Scroll.momentumArrestMode")
     
     /// Also see `ReactiveFlags` is this doesn't work
     
@@ -106,6 +107,39 @@ class ScrollTabController: NSViewController {
         /// Natural direction
         reverseDirection.bindingTarget <~ reverseDirectionToggle.reactive.boolValues
         reverseDirectionToggle.reactive.boolValue <~ reverseDirection.producer
+        
+        /// Momentum Arrest Mode
+        ///     Inline with the same style as "Smoothness:" and "Speed:" rows
+        
+        let momentumLabel = NSTextField(labelWithString: NSLocalizedString("momentum-arrest.label", comment: "Stop:"))
+        momentumLabel.font = NSFont.systemFont(ofSize: NSFont.systemFontSize)
+        momentumLabel.textColor = .labelColor
+        momentumLabel.setContentHuggingPriority(.required, for: .horizontal)
+        momentumLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
+        
+        let momentumPicker = NSPopUpButton(frame: .zero, pullsDown: false)
+        momentumPicker.addItem(withTitle: NSLocalizedString("momentum-arrest.off", comment: "Off"))
+        momentumPicker.lastItem?.identifier = NSUserInterfaceItemIdentifier("off")
+        momentumPicker.addItem(withTitle: NSLocalizedString("momentum-arrest.direction-change", comment: "Direction Change"))
+        momentumPicker.lastItem?.identifier = NSUserInterfaceItemIdentifier("directionChange")
+        momentumPicker.addItem(withTitle: NSLocalizedString("momentum-arrest.deceleration", comment: "Hard Stop (Free Spin)"))
+        momentumPicker.lastItem?.identifier = NSUserInterfaceItemIdentifier("deceleration")
+        
+        let momentumStack = NSStackView(views: [momentumLabel, momentumPicker])
+        momentumStack.orientation = .horizontal
+        momentumStack.alignment = .centerY
+        momentumStack.spacing = 5
+        
+        /// Insert into the master stack after the reverse direction toggle
+        if let reverseIndex = masterStack.arrangedSubviews.firstIndex(where: { $0 == reverseDirectionToggle.superview || $0 == reverseDirectionToggle }) {
+            masterStack.insertArrangedSubview(momentumStack, at: reverseIndex + 1)
+        } else {
+            masterStack.addArrangedSubview(momentumStack)
+        }
+        
+        /// Bind momentum picker to config
+        momentumArrestMode.bindingTarget <~ momentumPicker.reactive.selectedIdentifiers.map({ $0!.rawValue })
+        momentumPicker.reactive.selectedIdentifier <~ momentumArrestMode.producer.map({ NSUserInterfaceItemIdentifier($0) })
         
         /// Scroll speed
         scrollSpeed.bindingTarget <~ speedPicker.reactive.selectedIdentifiers.map({ identifier in

--- a/Helper/Core/Buttons/LogitechCIDActivator.h
+++ b/Helper/Core/Buttons/LogitechCIDActivator.h
@@ -1,0 +1,34 @@
+//
+// --------------------------------------------------------------------------
+// LogitechCIDActivator.h
+// Created for Mac Mouse Fix (https://github.com/noah-nuebling/mac-mouse-fix)
+// Created by Miguel Angelo in 2026
+// Licensed under the MMF License (https://github.com/noah-nuebling/mac-mouse-fix/blob/master/License)
+// --------------------------------------------------------------------------
+//
+// Activates Logitech HID++ 2.0 ReprogControlsV4 (feature 0x1B04) on attached
+// Logitech devices so that extra buttons (thumb, tilt wheel, precision, side
+// buttons) are diverted and reported as standard CGEvent mouse buttons that
+// Mac Mouse Fix can remap.
+//
+// References:
+//   - Solaar (pwr-Solaar/Solaar) hidpp20.py — flag byte "valid bit" pattern
+//   - libratbag hidpp20.c — TID definitions and GetCidInfo parsing
+//   - https://lekensteyn.nl/files/logitech/x1b04_specialkeysmsebuttons.html
+//
+
+#import <Foundation/Foundation.h>
+#import <IOKit/hid/IOHIDDevice.h>
+
+@interface LogitechCIDActivator : NSObject
+
++ (instancetype)shared;
+
+/// Call when a new device is attached. Activates CID diversion if the device
+/// is a Logitech mouse with ReprogControlsV4 support.
+- (void)handleDeviceAttached: (IOHIDDeviceRef)device;
+
+/// Call when a device is removed. Cleans up state for that device.
+- (void)handleDeviceRemoved: (IOHIDDeviceRef)device;
+
+@end

--- a/Helper/Core/Buttons/LogitechCIDActivator.m
+++ b/Helper/Core/Buttons/LogitechCIDActivator.m
@@ -1,0 +1,218 @@
+//
+// --------------------------------------------------------------------------
+// LogitechCIDActivator.m
+// Created for Mac Mouse Fix (https://github.com/noah-nuebling/mac-mouse-fix)
+// Created by Miguel Angelo in 2026
+// Licensed under the MMF License (https://github.com/noah-nuebling/mac-mouse-fix/blob/master/License)
+// --------------------------------------------------------------------------
+
+#import "LogitechCIDActivator.h"
+#import <IOKit/hid/IOHIDLib.h>
+#import <CoreGraphics/CoreGraphics.h>
+#import <AppKit/AppKit.h>
+#import "SharedUtility.h"
+#import "Mac_Mouse_Fix_Helper-Swift.h"
+#import "DeviceManager.h"
+
+#define kLogitechVID    0x046D
+#define kHIDPP_Long     0x11
+#define kHIDPP_Device   0xFF
+#define kFeat_ReprogV4  0x1B04
+
+/// SetCidReporting flags — Solaar hidpp20.py "valid bit" pattern:
+///   each flag bit has a corresponding valid bit = flag << 1
+///   0x03 = divert=1 (bit0) + divert_valid=1 (bit1)
+#define kDivertFlags    0x03
+
+/// TIDs of controls that already report natively — must NOT be diverted
+///   0x0038=left, 0x0039=right, 0x003A=middle, 0x003C=back, 0x003E=forward
+static const uint16_t kNativeTIDs[] = { 0x0038, 0x0039, 0x003A, 0x003C, 0x003E };
+
+/// CGEvent button numbers are 0-based. 5 = MMF "button 6" (first above L/R/M/Back/Fwd)
+#define kFirstCGButton  6
+
+typedef struct {
+    IOHIDDeviceRef  device;
+    uint8_t         reportBuf[64];
+    uint16_t        cidMap[32];
+    int             cidCount;
+    uint16_t        pressedCIDs[32];
+    int             pressedCount;
+} MFCIDDeviceState;
+
+static uint8_t sResp[20];
+static BOOL    sGotResp = NO;
+
+static BOOL isNativeTID(uint16_t tid) {
+    for (int i = 0; i < 5; i++) if (kNativeTIDs[i] == tid) return YES;
+    return NO;
+}
+
+static int buttonForCID(MFCIDDeviceState *s, uint16_t cid) {
+    for (int i = 0; i < s->cidCount; i++)
+        if (s->cidMap[i] == cid) return kFirstCGButton + i;
+    if (s->cidCount < 32) { s->cidMap[s->cidCount++] = cid; return kFirstCGButton + s->cidCount - 1; }
+    return kFirstCGButton;
+}
+
+static void injectButton(MFCIDDeviceState *s, uint16_t cid, BOOL down) {
+    int btn = buttonForCID(s, cid);
+    Device *device = [DeviceManager attachedDeviceWithIOHIDDevice: s->device];
+    if (!device) device = [Device strangeDevice];
+    CGEventRef event = CGEventCreate(NULL);
+    [Buttons handleInputWithDevice: device button: @(btn) downNotUp: down event: event];
+    CFRelease(event);
+}
+
+static void inputReportCallback(void *ctx, IOReturn result, void *sender,
+                                IOHIDReportType type, uint32_t reportID,
+                                uint8_t *report, CFIndex len) {
+    if (len < 5 || report[0] != kHIDPP_Long) return;
+    MFCIDDeviceState *s = (MFCIDDeviceState *)ctx;
+    if (report[3] != 0x00) {
+        memcpy(sResp, report, len < 20 ? (size_t)len : 20);
+        sGotResp = YES;
+        return;
+    }
+    uint16_t cid = ((uint16_t)report[4] << 8) | report[5];
+    if (cid == 0) {
+        for (int i = 0; i < s->pressedCount; i++) injectButton(s, s->pressedCIDs[i], NO);
+        s->pressedCount = 0;
+    } else {
+        for (int i = 0; i < s->pressedCount; i++) if (s->pressedCIDs[i] == cid) return;
+        injectButton(s, cid, YES);
+        if (s->pressedCount < 32) s->pressedCIDs[s->pressedCount++] = cid;
+    }
+}
+
+static IOReturn sendAndWait(IOHIDDeviceRef dev, uint8_t *pkt) {
+    sGotResp = NO;
+    IOReturn r = IOHIDDeviceSetReport(dev, kIOHIDReportTypeOutput, pkt[0], pkt, 20);
+    if (r != kIOReturnSuccess) return r;
+    for (int i = 0; i < 100 && !sGotResp; i++) CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.01, false);
+    if (!sGotResp) return kIOReturnTimeout;
+    if (sResp[2] == 0xFF) return kIOReturnError;
+    return kIOReturnSuccess;
+}
+
+static int activateDevice(IOHIDDeviceRef dev, MFCIDDeviceState *s) {
+    uint8_t pkt[20];
+
+    /// 1. GetFeature(0x1B04)
+    memset(pkt, 0, 20);
+    pkt[0]=kHIDPP_Long; pkt[1]=kHIDPP_Device; pkt[2]=0x00; pkt[3]=0x0E;
+    pkt[4]=(kFeat_ReprogV4>>8)&0xFF; pkt[5]=kFeat_ReprogV4&0xFF;
+    if (sendAndWait(dev, pkt) != kIOReturnSuccess || sResp[4] == 0) return 0;
+    uint8_t feat = sResp[4];
+
+    /// 2. GetCount
+    memset(pkt, 0, 20);
+    pkt[0]=kHIDPP_Long; pkt[1]=kHIDPP_Device; pkt[2]=feat; pkt[3]=0x0E;
+    if (sendAndWait(dev, pkt) != kIOReturnSuccess) return 0;
+    int count = sResp[4];
+
+    /// 3. GetCidInfo — collect divertable CIDs
+    uint16_t todivert[32]; int ndiv = 0;
+    for (int i = 0; i < count && ndiv < 32; i++) {
+        memset(pkt, 0, 20);
+        pkt[0]=kHIDPP_Long; pkt[1]=kHIDPP_Device; pkt[2]=feat; pkt[3]=0x1E; pkt[4]=(uint8_t)i;
+        if (sendAndWait(dev, pkt) != kIOReturnSuccess) continue;
+        uint16_t cid = ((uint16_t)sResp[4]<<8)|sResp[5];
+        uint16_t tid = ((uint16_t)sResp[6]<<8)|sResp[7];
+        uint8_t flags = sResp[8];
+        if ((flags & (1<<4)) && !isNativeTID(tid)) todivert[ndiv++] = cid;
+    }
+
+    /// 4. Pre-register button mapping for stable numbering
+    for (int i = 0; i < ndiv; i++) buttonForCID(s, todivert[i]);
+
+    /// 5. SetCidReporting — divert
+    int diverted = 0;
+    for (int i = 0; i < ndiv; i++) {
+        memset(pkt, 0, 20);
+        pkt[0]=kHIDPP_Long; pkt[1]=kHIDPP_Device; pkt[2]=feat; pkt[3]=0x3E;
+        pkt[4]=(todivert[i]>>8)&0xFF; pkt[5]=todivert[i]&0xFF; pkt[6]=kDivertFlags;
+        if (sendAndWait(dev, pkt) == kIOReturnSuccess) diverted++;
+    }
+    return diverted;
+}
+
+@interface LogitechCIDActivator ()
+@property (nonatomic) NSMutableArray *states;
+@property (nonatomic) NSTimer *reactivateTimer;
+@end
+
+@implementation LogitechCIDActivator
+
++ (instancetype)shared {
+    static LogitechCIDActivator *instance = nil;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{ instance = [self new]; });
+    return instance;
+}
+
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        _states = [NSMutableArray array];
+        /// Re-activate on system wake — firmware clears divert state on sleep
+        [[[NSWorkspace sharedWorkspace] notificationCenter]
+            addObserver: self
+               selector: @selector(reactivateAll)
+                   name: NSWorkspaceDidWakeNotification
+                 object: nil];
+        /// Periodic safety net — covers firmware timeout without sleep/wake cycle
+        _reactivateTimer = [NSTimer scheduledTimerWithTimeInterval: 60 * 30
+                                                           target: self
+                                                         selector: @selector(reactivateAll)
+                                                         userInfo: nil
+                                                          repeats: YES];
+    }
+    return self;
+}
+
+- (void)reactivateAll {
+    for (NSValue *v in _states) {
+        MFCIDDeviceState *s = (MFCIDDeviceState *)v.pointerValue;
+        activateDevice(s->device, s);
+    }
+    DDLogDebug(@"LogitechCIDActivator: re-activated %lu device(s)", (unsigned long)_states.count);
+}
+
+- (void)handleDeviceAttached: (IOHIDDeviceRef)device {
+    NSNumber *vid = (__bridge NSNumber *)IOHIDDeviceGetProperty(device, CFSTR(kIOHIDVendorIDKey));
+    if (vid.integerValue != kLogitechVID) return;
+    if (IOHIDDeviceOpen(device, kIOHIDOptionsTypeNone) != kIOReturnSuccess) return;
+
+    MFCIDDeviceState *s = calloc(1, sizeof(MFCIDDeviceState));
+    s->device = device;
+    IOHIDDeviceRegisterInputReportCallback(device, s->reportBuf, sizeof(s->reportBuf), inputReportCallback, s);
+    IOHIDDeviceScheduleWithRunLoop(device, CFRunLoopGetMain(), kCFRunLoopDefaultMode);
+
+    int diverted = activateDevice(device, s);
+    if (diverted > 0) {
+        NSString *name = (__bridge NSString *)IOHIDDeviceGetProperty(device, CFSTR(kIOHIDProductKey));
+        DDLogInfo(@"LogitechCIDActivator: diverted %d CIDs on '%@'", diverted, name);
+        [_states addObject: [NSValue valueWithPointer: s]];
+    } else {
+        IOHIDDeviceUnscheduleFromRunLoop(device, CFRunLoopGetMain(), kCFRunLoopDefaultMode);
+        IOHIDDeviceClose(device, kIOHIDOptionsTypeNone);
+        free(s);
+    }
+}
+
+- (void)handleDeviceRemoved: (IOHIDDeviceRef)device {
+    NSValue *found = nil;
+    for (NSValue *v in _states) {
+        if (((MFCIDDeviceState *)v.pointerValue)->device == device) { found = v; break; }
+    }
+    if (!found) return;
+    MFCIDDeviceState *s = (MFCIDDeviceState *)found.pointerValue;
+    for (int i = 0; i < s->pressedCount; i++) injectButton(s, s->pressedCIDs[i], NO);
+    IOHIDDeviceUnscheduleFromRunLoop(device, CFRunLoopGetMain(), kCFRunLoopDefaultMode);
+    IOHIDDeviceClose(device, kIOHIDOptionsTypeNone);
+    free(s);
+    [_states removeObject: found];
+}
+
+@end

--- a/Helper/Core/Config/ScrollConfig.swift
+++ b/Helper/Core/Config/ScrollConfig.swift
@@ -161,6 +161,16 @@ import CocoaLumberjackSwift
             } else if modifiers.effectMod == kMFScrollEffectModificationNone {
             } else if modifiers.effectMod == kMFScrollEffectModificationAddModeFeedback {
                 /// We don't wanna scroll at all in this case but I don't think it makes a difference.
+            } else if modifiers.effectMod == kMFScrollEffectModificationVolume {
+                
+                /// Disable animation — we want direct, immediate response
+                animationCurveOverride = kMFScrollAnimationCurveNameNone
+                
+            } else if modifiers.effectMod == kMFScrollEffectModificationBrightness {
+                
+                /// Disable animation — we want direct, immediate response
+                animationCurveOverride = kMFScrollAnimationCurveNameNone
+                
             } else {
                 assert(false);
             }
@@ -254,6 +264,22 @@ import CocoaLumberjackSwift
     @objc var useAppleAcceleration: Bool {
         return accelerationCurve == nil
     }
+    
+    /// Momentum arrest mode:
+    ///   - "off"           : Original behavior — cancel animation on direction change, swallow 1 tick
+    ///   - "directionChange": Enhanced — swallow 2 ticks on direction change, then allow reverse (good for notched wheels)
+    ///   - "deceleration"  : Detect wheel deceleration as stop signal (best for free-spinning/infinite scroll wheels)
+    /// Default: "deceleration"
+    @objc lazy var momentumArrestMode: NSString = {
+        if let val = c("momentumArrestMode") as? NSString {
+            return val
+        }
+        /// Legacy support: check old boolean key
+        if let val = c("momentumArrest") as? Bool {
+            return val ? "directionChange" as NSString : "off" as NSString
+        }
+        return "deceleration" as NSString
+    }()
     
     // MARK: Invert Direction
     

--- a/Helper/Core/Scroll/Scroll.m
+++ b/Helper/Core/Scroll/Scroll.m
@@ -28,6 +28,7 @@
 #import "Actions.h"
 #import "EventUtility.h"
 #import "MathObjc.h"
+#import "ScrollOutputUtility.h"
 
 @import IOKit;
 #import "MFHIDEventImports.h"
@@ -483,22 +484,109 @@ static void heavyProcessing(CGEventRef event, int64_t scrollDeltaAxis1, int64_t 
         }
         
         ///
-        /// Make direction change stop scroll animation
+        /// Make direction change / deceleration stop scroll animation
         ///
-        /// Notes:
-        /// - We implemented this here without much consideration to play around with it. I haven't really thought about the control flow and stuff - maybe it's not super clean to just return here? Maybe we should set pxToScrollForThisTick to zero? Idk. But I've been using it for a while and it works well.
-        /// - We used to have a threshold for the currentAnimationSpeed of 200 to actually cancel the animator, but it seems to feel nicer to just set the threshold to 0. At this point it might be simpler or more efficient to not use the `currentAnimationSpeed` here or use something else instead. Buttt the performance impact reallyyy shouldn't be significant and it works fine so it's whatever.
-        /// - Improvement idea: [Aug 2025]
-        ///     - Swallow the first 2 or 3 ticks of the scrollSwipe instead of just the 1st one.
-        ///         - Benefit:                  This would make it physically easier to avoid accidentally scrolling in the opposite direction
-        ///         - Implementation:     Should probably implement this in ScrollAnalyzer.m instead of doing a hack here
-        ///         - Credit for idea:       This email by 'A day of Software Engineer': (message:<510CF7AC-5BE0-4CED-BF9A-A3A3327EE2A5@gmail.com>)
+        /// Three modes controlled by `momentumArrestMode`:
+        ///   - "off"             : Original — cancel on direction change, swallow 1 tick
+        ///   - "directionChange" : Swallow 2 ticks on direction change, then allow reverse
+        ///   - "deceleration"    : Detect wheel stop via timeout (best for free-spinning wheels)
+        ///                         When ticks were fast and then stop arriving, arrest momentum.
+        ///                         Also includes directionChange behavior.
         
-        double currentAnimationSpeed = magnitudeOfVector(_animator.getLastAnimationSpeed);
-        if (_lastScrollAnalysisResult.scrollDirectionDidChange && currentAnimationSpeed > 0) {
-            DDLogDebug(@"Scroll.m: Direction change – cancel scroll.");
-            [_animator cancel];
-            return;
+        static int _directionChangeTicksSwallowed = 0;
+        static BOOL _momentumWasArrestedByDirectionChange = NO;
+        static dispatch_source_t _decelerationTimer = nil;
+        static BOOL _wasScrollingFast = NO;
+        
+        BOOL animatorIsRunning = _animator.isRunning;
+        NSString *arrestMode = (NSString *)_scrollConfig.momentumArrestMode;
+        BOOL useDeceleration = [arrestMode isEqualToString:@"deceleration"];
+        BOOL useDirectionChange = useDeceleration || [arrestMode isEqualToString:@"directionChange"];
+        
+        /// --- Deceleration detection (free-spinning wheel mode) ---
+        /// Detects hard-stop only: wheel spinning very fast then ticks stop completely.
+        /// Natural slowdown (gradual tick spacing increase) does NOT trigger this.
+        
+        if (useDeceleration) {
+            
+            double currentTimeBetweenTicks = scrollAnalysisResult.timeBetweenTicks;
+            BOOL isVeryFast = (currentTimeBetweenTicks != DBL_MAX && currentTimeBetweenTicks < 0.020);
+            
+            /// Cancel any existing timer (we got a new tick, so wheel is still moving)
+            if (_decelerationTimer != nil) {
+                dispatch_source_cancel(_decelerationTimer);
+                _decelerationTimer = nil;
+            }
+            
+            /// Only track "fast" state when ticks are very fast (< 20ms)
+            /// Reset immediately when ticks slow down — this prevents triggering during natural deceleration
+            if (isVeryFast) {
+                _wasScrollingFast = YES;
+            } else {
+                _wasScrollingFast = NO;
+            }
+            
+            /// Arm timer ONLY when wheel is currently spinning very fast.
+            /// If the wheel naturally slows down, _wasScrollingFast becomes NO and timer won't arm.
+            /// Timer only fires if ticks were very fast and then NOTHING arrives for 100ms (hard stop).
+            if (_wasScrollingFast && _animator.isRunning) {
+                _decelerationTimer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, _scrollQueue);
+                dispatch_source_set_timer(_decelerationTimer, dispatch_time(DISPATCH_TIME_NOW, 100 * NSEC_PER_MSEC), DISPATCH_TIME_FOREVER, 5 * NSEC_PER_MSEC);
+                dispatch_source_set_event_handler(_decelerationTimer, ^{
+                    if (_animator.isRunning) {
+                        DDLogDebug(@"Scroll.m: Hard stop detected – wheel went from fast to zero ticks.");
+                        [_animator cancel];
+                        [GestureScrollSimulator stopMomentumScroll];
+                    }
+                    _wasScrollingFast = NO;
+                    _decelerationTimer = nil;
+                });
+                dispatch_resume(_decelerationTimer);
+            }
+        }
+        
+        /// --- Direction change handling ---
+        
+        if (_lastScrollAnalysisResult.scrollDirectionDidChange) {
+            
+            if (useDirectionChange) {
+                /// Enhanced momentum arrest (trackpad-like)
+                
+                if (animatorIsRunning) {
+                    DDLogDebug(@"Scroll.m: Direction change – arresting momentum.");
+                    [_animator cancel];
+                    [GestureScrollSimulator stopMomentumScroll];
+                    _momentumWasArrestedByDirectionChange = YES;
+                    _directionChangeTicksSwallowed = 0;
+                    _wasScrollingFast = NO;
+                    if (_decelerationTimer != nil) {
+                        dispatch_source_cancel(_decelerationTimer);
+                        _decelerationTimer = nil;
+                    }
+                }
+                
+                if (_momentumWasArrestedByDirectionChange) {
+                    _directionChangeTicksSwallowed += 1;
+                    if (_directionChangeTicksSwallowed <= 2) {
+                        DDLogDebug(@"Scroll.m: Direction change – swallowing tick %d (momentum arrest).", _directionChangeTicksSwallowed);
+                        return;
+                    }
+                }
+                
+            } else {
+                /// "off" mode: cancel and swallow first tick
+                double currentAnimationSpeed = magnitudeOfVector(_animator.getLastAnimationSpeed);
+                if (currentAnimationSpeed > 0) {
+                    DDLogDebug(@"Scroll.m: Direction change – cancel scroll (legacy).");
+                    [_animator cancel];
+                    return;
+                }
+            }
+            
+        } else {
+            /// Direction didn't change — reset arrest state
+            _momentumWasArrestedByDirectionChange = NO;
+            _directionChangeTicksSwallowed = 0;
         }
         
         /// Debug
@@ -845,6 +933,10 @@ static void sendScroll(int64_t px, MFDirection scrollDirection, BOOL animated, M
         outputType = kMFScrollOutputTypeCommandTab;
     } else if (_modifications.effectMod == kMFScrollEffectModificationThreeFingerSwipeHorizontal) {
         outputType = kMFScrollOutputTypeThreeFingerSwipeHorizontal;
+    } else if (_modifications.effectMod == kMFScrollEffectModificationVolume) {
+        outputType = kMFScrollOutputTypeVolume;
+    } else if (_modifications.effectMod == kMFScrollEffectModificationBrightness) {
+        outputType = kMFScrollOutputTypeBrightness;
     } /// kMFScrollEffectModificationHorizontalScroll is handled above when determining scroll direction
     
     /// Send event
@@ -863,6 +955,8 @@ typedef enum {
     kMFScrollOutputTypeZoom,
     kMFScrollOutputTypeRotation,
     kMFScrollOutputTypeCommandTab,
+    kMFScrollOutputTypeVolume,
+    kMFScrollOutputTypeBrightness,
 } MFScrollOutputType;
 
 /// Output
@@ -1244,6 +1338,32 @@ static void sendOutputEvents(int64_t dx, int64_t dy, MFScrollOutputType outputTy
                 sendKeyEvent(48, kCGEventFlagMaskCommand | kCGEventFlagMaskShift, false);
             }
         }
+        
+    } else if (outputType == kMFScrollOutputTypeVolume) {
+        
+        /// --- Volume ---
+        /// Smoothly adjust system volume using CoreAudio scalar API
+        
+        double d = dx + dy;
+        if (d == 0) return;
+        
+        float currentVolume = [ScrollOutputUtility getSystemVolume];
+        float delta = (float)(d / 4000.0); /// Scale scroll delta to a small volume increment
+        float newVolume = currentVolume + delta;
+        [ScrollOutputUtility setSystemVolume:newVolume]; /// Clamping is handled internally
+        
+    } else if (outputType == kMFScrollOutputTypeBrightness) {
+        
+        /// --- Brightness ---
+        /// Smoothly adjust display brightness using DisplayServices private framework
+        
+        double d = dx + dy;
+        if (d == 0) return;
+        
+        float currentBrightness = [ScrollOutputUtility getDisplayBrightness];
+        float delta = (float)(d / 4000.0); /// Scale scroll delta to a small brightness increment
+        float newBrightness = currentBrightness + delta;
+        [ScrollOutputUtility setDisplayBrightness:newBrightness]; /// Clamping is handled internally
         
     } else {
         assert(false);

--- a/Localization/en.lproj/Localizable.strings
+++ b/Localization/en.lproj/Localizable.strings
@@ -137,6 +137,18 @@
 /* First draft: Learn More */
 "capture-toast.link" = "Learn More";
 
+/* Brightness */
+"drag-effect.brightness" = "Brightness";
+
+/* Brightness (Horizontal) */
+"drag-effect.brightness-horizontal" = "Brightness (Horizontal)";
+
+/* Smoothly adjust display brightness by moving your mouse left and right\n \nMove right to increase, move left to decrease */
+"drag-effect.brightness-horizontal.hint" = "Smoothly adjust display brightness by moving your mouse left and right\n \nMove right to increase, move left to decrease";
+
+/* Smoothly adjust display brightness by moving your mouse up and down\n \nMove up to increase, move down to decrease */
+"drag-effect.brightness.hint" = "Smoothly adjust display brightness by moving your mouse up and down\n \nMove up to increase, move down to decrease";
+
 /* First draft: Spaces & Mission Control */
 "drag-effect.dock-swipe" = "Spaces & Mission Control";
 
@@ -148,6 +160,18 @@
 
 /* First draft: Scroll freely by moving your mouse in any direction\n \nAlso Navigate between pages in Safari, delete messages in Mail and more by moving your mouse left and right\n \nWorks like swiping with 2 fingers on an Apple Trackpad */
 "drag-effect.scroll-swipe.hint" = "Scroll freely by moving your mouse in any direction\n \nAlso Navigate between pages in Safari, delete messages in Mail and more by moving your mouse left and right\n \nWorks like swiping with 2 fingers on an Apple Trackpad";
+
+/* Volume */
+"drag-effect.volume" = "Volume";
+
+/* Volume (Horizontal) */
+"drag-effect.volume-horizontal" = "Volume (Horizontal)";
+
+/* Smoothly adjust system volume by moving your mouse left and right\n \nMove right to increase, move left to decrease */
+"drag-effect.volume-horizontal.hint" = "Smoothly adjust system volume by moving your mouse left and right\n \nMove right to increase, move left to decrease";
+
+/* Smoothly adjust system volume by moving your mouse up and down\n \nMove up to increase, move down to decrease */
+"drag-effect.volume.hint" = "Smoothly adjust system volume by moving your mouse up and down\n \nMove up to increase, move down to decrease";
 
 /* First draft: Application Windows || Note: Under macOS Sonoma, this feature is called 'App Exposé' in Trackpad settings, but 'Application Windows' in Keyboard Shortcut settings and all other places I found. */
 "effect.app-expose" = "Application Windows";
@@ -338,6 +362,18 @@
 /* First draft: Shift (⇧) */
 "modifer-key.tool.shift" = "Shift (⇧)";
 
+/* Hard Stop (Free Spin) */
+"momentum-arrest.deceleration" = "Hard Stop (Free Spin)";
+
+/* Direction Change */
+"momentum-arrest.direction-change" = "Direction Change";
+
+/* Stop: */
+"momentum-arrest.label" = "Stop:";
+
+/* Off */
+"momentum-arrest.off" = "Off";
+
 /* First draft: Scroll precisely, even without a keyboard modifier,\nbymoving the scroll wheel _slowly_ || Note: The line break (\n) is there so the layout of the Scroll tab doesn't become too wide which looks weird. You can set it to your own taste. */
 "precise-scrolling-hint" = "Scroll precisely, even without a keyboard modifier,\nby moving the scroll wheel _slowly_";
 
@@ -383,6 +419,12 @@
 /* First draft: Quickly switch between open apps\n \nWorks like holding Command (⌘) and then pressing Tab (⇥) on your keyboard */
 "scroll-effect.app-switcher.hint" = "Quickly switch between open apps\n \nWorks like holding Command (⌘) and then pressing Tab (⇥) on your keyboard";
 
+/* Brightness */
+"scroll-effect.brightness" = "Brightness";
+
+/* Smoothly adjust display brightness\n \nScroll up to increase, scroll down to decrease */
+"scroll-effect.brightness.hint" = "Smoothly adjust display brightness\n \nScroll up to increase, scroll down to decrease";
+
 /* First draft: Horizontal Scroll */
 "scroll-effect.horizontal" = "Horizontal Scroll";
 
@@ -412,6 +454,12 @@
 
 /* First draft: Scroll long distances with minimal effort */
 "scroll-effect.swift.hint" = "Scroll long distances with minimal effort";
+
+/* Volume */
+"scroll-effect.volume" = "Volume";
+
+/* Smoothly adjust system volume\n \nScroll up to increase, scroll down to decrease */
+"scroll-effect.volume.hint" = "Smoothly adjust system volume\n \nScroll up to increase, scroll down to decrease";
 
 /* First draft: Zoom In or Out */
 "scroll-effect.zoom" = "Zoom In or Out";

--- a/Shared/Devices/DeviceManager.m
+++ b/Shared/Devices/DeviceManager.m
@@ -32,6 +32,7 @@
 
 #import "SharedUtility.h"
 #import "Mac_Mouse_Fix_Helper-Swift.h"
+#import "LogitechCIDActivator.h"
 
 @implementation DeviceManager
 
@@ -267,6 +268,9 @@ static void handleDeviceMatching(void *context, IOReturn result, void *sender, I
         
     #endif
         
+        /// Activate Logitech HID++ CID diversion for extra buttons
+        [[LogitechCIDActivator shared] handleDeviceAttached: device];
+
         /// Log
         DDLogInfo(@"New device added to attached devices:\n%@", newDevice);
         
@@ -307,6 +311,9 @@ static void handleDeviceRemoval(void *context, IOReturn result, void *sender, IO
 //        [Scroll decide];
 //        [ButtonInputReceiver decide];
         
+        /// Clean up Logitech CID diversion
+        [[LogitechCIDActivator shared] handleDeviceRemoved: device];
+
         /// Log
         
         DDLogInfo(@"Attached device was removed:\n%@", attachedDevice);


### PR DESCRIPTION
## Summary

Adds trackpad-like momentum arrest for scroll wheels. When the page is coasting from scroll momentum, scrolling in the opposite direction (or stopping a free-spinning wheel) immediately arrests the momentum — just like touching a trackpad surface stops the page.

## Three modes (configurable in Scroll tab UI)

- **Off**: Original behavior (cancel + swallow 1 tick on direction change)
- **Direction Change**: Swallow first 2 ticks on reverse scroll ("fingers down to stop"), then allow reverse scrolling on 3+ ticks ("deliberate flick"). Best for notched wheels.
- **Hard Stop (Free Spin)**: Detects when a fast-spinning wheel suddenly stops sending ticks (timeout-based). Immediately arrests on-screen momentum. Best for Logitech MX Master and similar infinite scroll wheels.

## Implementation

- Config key: `Scroll.momentumArrestMode` (values: `off`, `directionChange`, `deceleration`)
- UI: NSPopUpButton added programmatically in ScrollTabController
- Logic in `Scroll.m` `heavyProcessing()` — replaces the existing direction-change handling
- Uses `dispatch_source_t` timer on the scroll queue for hard-stop detection

## Testing

Tested with Logitech MX Master 3S (free-spinning wheel) and standard notched wheel mice. The direction-change mode works well for both; the hard-stop mode is specifically tuned for infinite scroll wheels.

## Files changed

- `Helper/Core/Scroll/Scroll.m` — momentum arrest logic
- `Helper/Core/Config/ScrollConfig.swift` — `momentumArrestMode` property
- `App/UI/Main/Tabs/ScrollTabController.swift` — UI picker
- `Localization/en.lproj/Localizable.strings` — labels