### PR TITLE
Add volume and brightness control via scroll wheel and drag

### DIFF
--- a/App/UI/Main/Tabs/ButtonTab/RemapTable/RemapTableTranslator.m
+++ b/App/UI/Main/Tabs/ButtonTab/RemapTable/RemapTableTranslator.m
@@ -92,6 +92,13 @@ static NSArray *getScrollEffectsTable() {
             kMFModifiedScrollDictKeyEffectModificationType: kMFModifiedScrollEffectModificationTypeRotate
         }}, /// We only have this option so the menu layout looks better. I can't really think of a usecase
         separatorEffectsTableEntry(),
+        @{@"ui": NSLocalizedString(@"scroll-effect.volume", @"Volume"), @"tool": NSLocalizedString(@"scroll-effect.volume.hint", @"Smoothly adjust system volume\n \nScroll up to increase, scroll down to decrease"), @"dict": @{
+            kMFModifiedScrollDictKeyEffectModificationType: kMFModifiedScrollEffectModificationTypeVolume
+        }},
+        @{@"ui": NSLocalizedString(@"scroll-effect.brightness", @"Brightness"), @"tool": NSLocalizedString(@"scroll-effect.brightness.hint", @"Smoothly adjust display brightness\n \nScroll up to increase, scroll down to decrease"), @"dict": @{
+            kMFModifiedScrollDictKeyEffectModificationType: kMFModifiedScrollEffectModificationTypeBrightness
+        }},
+        separatorEffectsTableEntry(),
         @{@"ui": NSLocalizedString(@"scroll-effect.swift", @"First draft: Swift Scroll"), @"tool": NSLocalizedString(@"scroll-effect.swift.hint", @"First draft: Scroll long distances with minimal effort"), @"dict": @{
             kMFModifiedScrollDictKeyInputModificationType: kMFModifiedScrollInputModificationTypeQuickScroll
         }},
@@ -125,6 +132,19 @@ static NSArray *getDragEffectsTable() {
 //                  kMFModifiedDragDictKeyType: kMFModifiedDragTypeFakeDrag,
 //                  kMFModifiedDragDictKeyFakeDragVariantButtonNumber: @3,
 //        }},
+        separatorEffectsTableEntry(),
+        @{@"ui": NSLocalizedString(@"drag-effect.volume", @"Volume"), @"tool": NSLocalizedString(@"drag-effect.volume.hint", @"Smoothly adjust system volume by moving your mouse up and down\n \nMove up to increase, move down to decrease"), @"dict": @{
+                  kMFModifiedDragDictKeyType: kMFModifiedDragTypeVolume,
+        }},
+        @{@"ui": NSLocalizedString(@"drag-effect.brightness", @"Brightness"), @"tool": NSLocalizedString(@"drag-effect.brightness.hint", @"Smoothly adjust display brightness by moving your mouse up and down\n \nMove up to increase, move down to decrease"), @"dict": @{
+                  kMFModifiedDragDictKeyType: kMFModifiedDragTypeBrightness,
+        }},
+        @{@"ui": NSLocalizedString(@"drag-effect.volume-horizontal", @"Volume (Horizontal)"), @"tool": NSLocalizedString(@"drag-effect.volume-horizontal.hint", @"Smoothly adjust system volume by moving your mouse left and right\n \nMove right to increase, move left to decrease"), @"dict": @{
+                  kMFModifiedDragDictKeyType: kMFModifiedDragTypeVolumeHorizontal,
+        }},
+        @{@"ui": NSLocalizedString(@"drag-effect.brightness-horizontal", @"Brightness (Horizontal)"), @"tool": NSLocalizedString(@"drag-effect.brightness-horizontal.hint", @"Smoothly adjust display brightness by moving your mouse left and right\n \nMove right to increase, move left to decrease"), @"dict": @{
+                  kMFModifiedDragDictKeyType: kMFModifiedDragTypeBrightnessHorizontal,
+        }},
     ];
     return dragEffectsTable;
 }

--- a/FUTURE_FEATURES.md
+++ b/FUTURE_FEATURES.md
@@ -1,0 +1,30 @@
+# Future Features
+
+## Trackpad Gesture Translations
+- Two-finger rotate via drag (hold button + move mouse to rotate in Maps, Photos, Preview)
+- Notification Centre swipe (simulate two-finger swipe from right edge)
+- Force Touch / Lookup simulation (map button to force touch event for word lookup, Quick Look, etc.)
+- Smart Zoom (double-tap-with-two-fingers equivalent mapped to a button)
+- Fake trackpad presence toggle (always send gesture-scroll events so pro apps like Logic/Final Cut unlock trackpad behaviors)
+
+## Scroll Enhancements
+- Inertia injection (trailing momentum coast after fast scrolling stops, trackpad-flick feel)
+- Per-app momentum duration tuning
+- Momentum arrest button action (dedicated button to instantly kill momentum)
+
+## Drag-Based Controls
+- Window resize via button+scroll
+- Window move via button+drag
+- Window opacity control via button+scroll
+- Timeline scrubbing (send left/right arrow keys from scroll)
+- Playback speed control via scroll
+
+## System Controls
+- Scroll on menu bar to change audio output device
+- Scroll on dock icon to cycle app windows
+
+## UX / Quality of Life
+- Visual indicator in menu bar showing active modifier/mode
+- Import/export button configs as JSON
+- Quick toggle shortcut to temporarily disable MMF (gaming mode)
+- Logitech thumb button as modifier layer (changes what all other buttons do)

--- a/Helper/Core/Buttons/LogitechCIDActivator.h
+++ b/Helper/Core/Buttons/LogitechCIDActivator.h
@@ -1,0 +1,34 @@
+//
+// --------------------------------------------------------------------------
+// LogitechCIDActivator.h
+// Created for Mac Mouse Fix (https://github.com/noah-nuebling/mac-mouse-fix)
+// Created by Miguel Angelo in 2026
+// Licensed under the MMF License (https://github.com/noah-nuebling/mac-mouse-fix/blob/master/License)
+// --------------------------------------------------------------------------
+//
+// Activates Logitech HID++ 2.0 ReprogControlsV4 (feature 0x1B04) on attached
+// Logitech devices so that extra buttons (thumb, tilt wheel, precision, side
+// buttons) are diverted and reported as standard CGEvent mouse buttons that
+// Mac Mouse Fix can remap.
+//
+// References:
+//   - Solaar (pwr-Solaar/Solaar) hidpp20.py — flag byte "valid bit" pattern
+//   - libratbag hidpp20.c — TID definitions and GetCidInfo parsing
+//   - https://lekensteyn.nl/files/logitech/x1b04_specialkeysmsebuttons.html
+//
+
+#import <Foundation/Foundation.h>
+#import <IOKit/hid/IOHIDDevice.h>
+
+@interface LogitechCIDActivator : NSObject
+
++ (instancetype)shared;
+
+/// Call when a new device is attached. Activates CID diversion if the device
+/// is a Logitech mouse with ReprogControlsV4 support.
+- (void)handleDeviceAttached: (IOHIDDeviceRef)device;
+
+/// Call when a device is removed. Cleans up state for that device.
+- (void)handleDeviceRemoved: (IOHIDDeviceRef)device;
+
+@end

--- a/Helper/Core/Buttons/LogitechCIDActivator.m
+++ b/Helper/Core/Buttons/LogitechCIDActivator.m
@@ -1,0 +1,218 @@
+//
+// --------------------------------------------------------------------------
+// LogitechCIDActivator.m
+// Created for Mac Mouse Fix (https://github.com/noah-nuebling/mac-mouse-fix)
+// Created by Miguel Angelo in 2026
+// Licensed under the MMF License (https://github.com/noah-nuebling/mac-mouse-fix/blob/master/License)
+// --------------------------------------------------------------------------
+
+#import "LogitechCIDActivator.h"
+#import <IOKit/hid/IOHIDLib.h>
+#import <CoreGraphics/CoreGraphics.h>
+#import <AppKit/AppKit.h>
+#import "SharedUtility.h"
+#import "Mac_Mouse_Fix_Helper-Swift.h"
+#import "DeviceManager.h"
+
+#define kLogitechVID    0x046D
+#define kHIDPP_Long     0x11
+#define kHIDPP_Device   0xFF
+#define kFeat_ReprogV4  0x1B04
+
+/// SetCidReporting flags — Solaar hidpp20.py "valid bit" pattern:
+///   each flag bit has a corresponding valid bit = flag << 1
+///   0x03 = divert=1 (bit0) + divert_valid=1 (bit1)
+#define kDivertFlags    0x03
+
+/// TIDs of controls that already report natively — must NOT be diverted
+///   0x0038=left, 0x0039=right, 0x003A=middle, 0x003C=back, 0x003E=forward
+static const uint16_t kNativeTIDs[] = { 0x0038, 0x0039, 0x003A, 0x003C, 0x003E };
+
+/// CGEvent button numbers are 0-based. 5 = MMF "button 6" (first above L/R/M/Back/Fwd)
+#define kFirstCGButton  6
+
+typedef struct {
+    IOHIDDeviceRef  device;
+    uint8_t         reportBuf[64];
+    uint16_t        cidMap[32];
+    int             cidCount;
+    uint16_t        pressedCIDs[32];
+    int             pressedCount;
+} MFCIDDeviceState;
+
+static uint8_t sResp[20];
+static BOOL    sGotResp = NO;
+
+static BOOL isNativeTID(uint16_t tid) {
+    for (int i = 0; i < 5; i++) if (kNativeTIDs[i] == tid) return YES;
+    return NO;
+}
+
+static int buttonForCID(MFCIDDeviceState *s, uint16_t cid) {
+    for (int i = 0; i < s->cidCount; i++)
+        if (s->cidMap[i] == cid) return kFirstCGButton + i;
+    if (s->cidCount < 32) { s->cidMap[s->cidCount++] = cid; return kFirstCGButton + s->cidCount - 1; }
+    return kFirstCGButton;
+}
+
+static void injectButton(MFCIDDeviceState *s, uint16_t cid, BOOL down) {
+    int btn = buttonForCID(s, cid);
+    Device *device = [DeviceManager attachedDeviceWithIOHIDDevice: s->device];
+    if (!device) device = [Device strangeDevice];
+    CGEventRef event = CGEventCreate(NULL);
+    [Buttons handleInputWithDevice: device button: @(btn) downNotUp: down event: event];
+    CFRelease(event);
+}
+
+static void inputReportCallback(void *ctx, IOReturn result, void *sender,
+                                IOHIDReportType type, uint32_t reportID,
+                                uint8_t *report, CFIndex len) {
+    if (len < 5 || report[0] != kHIDPP_Long) return;
+    MFCIDDeviceState *s = (MFCIDDeviceState *)ctx;
+    if (report[3] != 0x00) {
+        memcpy(sResp, report, len < 20 ? (size_t)len : 20);
+        sGotResp = YES;
+        return;
+    }
+    uint16_t cid = ((uint16_t)report[4] << 8) | report[5];
+    if (cid == 0) {
+        for (int i = 0; i < s->pressedCount; i++) injectButton(s, s->pressedCIDs[i], NO);
+        s->pressedCount = 0;
+    } else {
+        for (int i = 0; i < s->pressedCount; i++) if (s->pressedCIDs[i] == cid) return;
+        injectButton(s, cid, YES);
+        if (s->pressedCount < 32) s->pressedCIDs[s->pressedCount++] = cid;
+    }
+}
+
+static IOReturn sendAndWait(IOHIDDeviceRef dev, uint8_t *pkt) {
+    sGotResp = NO;
+    IOReturn r = IOHIDDeviceSetReport(dev, kIOHIDReportTypeOutput, pkt[0], pkt, 20);
+    if (r != kIOReturnSuccess) return r;
+    for (int i = 0; i < 100 && !sGotResp; i++) CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.01, false);
+    if (!sGotResp) return kIOReturnTimeout;
+    if (sResp[2] == 0xFF) return kIOReturnError;
+    return kIOReturnSuccess;
+}
+
+static int activateDevice(IOHIDDeviceRef dev, MFCIDDeviceState *s) {
+    uint8_t pkt[20];
+
+    /// 1. GetFeature(0x1B04)
+    memset(pkt, 0, 20);
+    pkt[0]=kHIDPP_Long; pkt[1]=kHIDPP_Device; pkt[2]=0x00; pkt[3]=0x0E;
+    pkt[4]=(kFeat_ReprogV4>>8)&0xFF; pkt[5]=kFeat_ReprogV4&0xFF;
+    if (sendAndWait(dev, pkt) != kIOReturnSuccess || sResp[4] == 0) return 0;
+    uint8_t feat = sResp[4];
+
+    /// 2. GetCount
+    memset(pkt, 0, 20);
+    pkt[0]=kHIDPP_Long; pkt[1]=kHIDPP_Device; pkt[2]=feat; pkt[3]=0x0E;
+    if (sendAndWait(dev, pkt) != kIOReturnSuccess) return 0;
+    int count = sResp[4];
+
+    /// 3. GetCidInfo — collect divertable CIDs
+    uint16_t todivert[32]; int ndiv = 0;
+    for (int i = 0; i < count && ndiv < 32; i++) {
+        memset(pkt, 0, 20);
+        pkt[0]=kHIDPP_Long; pkt[1]=kHIDPP_Device; pkt[2]=feat; pkt[3]=0x1E; pkt[4]=(uint8_t)i;
+        if (sendAndWait(dev, pkt) != kIOReturnSuccess) continue;
+        uint16_t cid = ((uint16_t)sResp[4]<<8)|sResp[5];
+        uint16_t tid = ((uint16_t)sResp[6]<<8)|sResp[7];
+        uint8_t flags = sResp[8];
+        if ((flags & (1<<4)) && !isNativeTID(tid)) todivert[ndiv++] = cid;
+    }
+
+    /// 4. Pre-register button mapping for stable numbering
+    for (int i = 0; i < ndiv; i++) buttonForCID(s, todivert[i]);
+
+    /// 5. SetCidReporting — divert
+    int diverted = 0;
+    for (int i = 0; i < ndiv; i++) {
+        memset(pkt, 0, 20);
+        pkt[0]=kHIDPP_Long; pkt[1]=kHIDPP_Device; pkt[2]=feat; pkt[3]=0x3E;
+        pkt[4]=(todivert[i]>>8)&0xFF; pkt[5]=todivert[i]&0xFF; pkt[6]=kDivertFlags;
+        if (sendAndWait(dev, pkt) == kIOReturnSuccess) diverted++;
+    }
+    return diverted;
+}
+
+@interface LogitechCIDActivator ()
+@property (nonatomic) NSMutableArray *states;
+@property (nonatomic) NSTimer *reactivateTimer;
+@end
+
+@implementation LogitechCIDActivator
+
++ (instancetype)shared {
+    static LogitechCIDActivator *instance = nil;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{ instance = [self new]; });
+    return instance;
+}
+
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        _states = [NSMutableArray array];
+        /// Re-activate on system wake — firmware clears divert state on sleep
+        [[[NSWorkspace sharedWorkspace] notificationCenter]
+            addObserver: self
+               selector: @selector(reactivateAll)
+                   name: NSWorkspaceDidWakeNotification
+                 object: nil];
+        /// Periodic safety net — covers firmware timeout without sleep/wake cycle
+        _reactivateTimer = [NSTimer scheduledTimerWithTimeInterval: 60 * 30
+                                                           target: self
+                                                         selector: @selector(reactivateAll)
+                                                         userInfo: nil
+                                                          repeats: YES];
+    }
+    return self;
+}
+
+- (void)reactivateAll {
+    for (NSValue *v in _states) {
+        MFCIDDeviceState *s = (MFCIDDeviceState *)v.pointerValue;
+        activateDevice(s->device, s);
+    }
+    DDLogDebug(@"LogitechCIDActivator: re-activated %lu device(s)", (unsigned long)_states.count);
+}
+
+- (void)handleDeviceAttached: (IOHIDDeviceRef)device {
+    NSNumber *vid = (__bridge NSNumber *)IOHIDDeviceGetProperty(device, CFSTR(kIOHIDVendorIDKey));
+    if (vid.integerValue != kLogitechVID) return;
+    if (IOHIDDeviceOpen(device, kIOHIDOptionsTypeNone) != kIOReturnSuccess) return;
+
+    MFCIDDeviceState *s = calloc(1, sizeof(MFCIDDeviceState));
+    s->device = device;
+    IOHIDDeviceRegisterInputReportCallback(device, s->reportBuf, sizeof(s->reportBuf), inputReportCallback, s);
+    IOHIDDeviceScheduleWithRunLoop(device, CFRunLoopGetMain(), kCFRunLoopDefaultMode);
+
+    int diverted = activateDevice(device, s);
+    if (diverted > 0) {
+        NSString *name = (__bridge NSString *)IOHIDDeviceGetProperty(device, CFSTR(kIOHIDProductKey));
+        DDLogInfo(@"LogitechCIDActivator: diverted %d CIDs on '%@'", diverted, name);
+        [_states addObject: [NSValue valueWithPointer: s]];
+    } else {
+        IOHIDDeviceUnscheduleFromRunLoop(device, CFRunLoopGetMain(), kCFRunLoopDefaultMode);
+        IOHIDDeviceClose(device, kIOHIDOptionsTypeNone);
+        free(s);
+    }
+}
+
+- (void)handleDeviceRemoved: (IOHIDDeviceRef)device {
+    NSValue *found = nil;
+    for (NSValue *v in _states) {
+        if (((MFCIDDeviceState *)v.pointerValue)->device == device) { found = v; break; }
+    }
+    if (!found) return;
+    MFCIDDeviceState *s = (MFCIDDeviceState *)found.pointerValue;
+    for (int i = 0; i < s->pressedCount; i++) injectButton(s, s->pressedCIDs[i], NO);
+    IOHIDDeviceUnscheduleFromRunLoop(device, CFRunLoopGetMain(), kCFRunLoopDefaultMode);
+    IOHIDDeviceClose(device, kIOHIDOptionsTypeNone);
+    free(s);
+    [_states removeObject: found];
+}
+
+@end

--- a/Helper/Core/Drag/ModifiedDrag.m
+++ b/Helper/Core/Drag/ModifiedDrag.m
@@ -31,6 +31,7 @@
 #import "ModifiedDragOutputTwoFingerSwipe.h"
 #import "ModifiedDragOutputFakeDrag.h"
 #import "ModifiedDragOutputAddMode.h"
+#import "ModifiedDragOutputVolumeBrightness.h"
 
 #import "GlobalEventTapThread.h"
 
@@ -170,6 +171,14 @@ static ModifiedDragState _drag;
             p = (id<ModifiedDragOutputPlugin>)ModifiedDragOutputFakeDrag.class;
         } else if ([type isEqualToString:kMFModifiedDragTypeAddModeFeedback]) {
             p = (id<ModifiedDragOutputPlugin>)ModifiedDragOutputAddMode.class;
+        } else if ([type isEqualToString:kMFModifiedDragTypeVolume]) {
+            p = (id<ModifiedDragOutputPlugin>)ModifiedDragOutputVolumeBrightness.class;
+        } else if ([type isEqualToString:kMFModifiedDragTypeBrightness]) {
+            p = (id<ModifiedDragOutputPlugin>)ModifiedDragOutputVolumeBrightness.class;
+        } else if ([type isEqualToString:kMFModifiedDragTypeVolumeHorizontal]) {
+            p = (id<ModifiedDragOutputPlugin>)ModifiedDragOutputVolumeBrightness.class;
+        } else if ([type isEqualToString:kMFModifiedDragTypeBrightnessHorizontal]) {
+            p = (id<ModifiedDragOutputPlugin>)ModifiedDragOutputVolumeBrightness.class;
         } else {
             assert(false);
         }

--- a/Helper/Core/Drag/ModifiedDragOutputVolumeBrightness.h
+++ b/Helper/Core/Drag/ModifiedDragOutputVolumeBrightness.h
@@ -1,0 +1,19 @@
+//
+// --------------------------------------------------------------------------
+// ModifiedDragOutputVolumeBrightness.h
+// Created for Mac Mouse Fix (https://github.com/noah-nuebling/mac-mouse-fix)
+// Created for volume and brightness drag control
+// Licensed under the MMF License (https://github.com/noah-nuebling/mac-mouse-fix/blob/master/License)
+// --------------------------------------------------------------------------
+//
+
+#import <Foundation/Foundation.h>
+#import "ModifiedDrag.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ModifiedDragOutputVolumeBrightness : NSObject <ModifiedDragOutputPlugin>
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Helper/Core/Drag/ModifiedDragOutputVolumeBrightness.m
+++ b/Helper/Core/Drag/ModifiedDragOutputVolumeBrightness.m
@@ -1,0 +1,64 @@
+//
+// --------------------------------------------------------------------------
+// ModifiedDragOutputVolumeBrightness.m
+// Created for Mac Mouse Fix (https://github.com/noah-nuebling/mac-mouse-fix)
+// Created for volume and brightness drag control
+// Licensed under the MMF License (https://github.com/noah-nuebling/mac-mouse-fix/blob/master/License)
+// --------------------------------------------------------------------------
+//
+
+#import "ModifiedDragOutputVolumeBrightness.h"
+#import "ScrollOutputUtility.h"
+#import "Constants.h"
+
+@implementation ModifiedDragOutputVolumeBrightness
+
+#pragma mark - Vars
+
+static ModifiedDragState *_drag;
+
+#pragma mark - Interface
+
++ (void)initializeWithDragState:(ModifiedDragState *)dragStateRef {
+    _drag = dragStateRef;
+}
+
++ (void)handleBecameInUse {
+    /// Nothing special needed on activation
+}
+
++ (void)handleMouseInputWhileInUseWithDeltaX:(double)deltaX deltaY:(double)deltaY event:(CGEventRef)event {
+    
+    /// Scale: ~400px of mouse movement = full range (0.0 to 1.0)
+    /// Vertical: up (negative deltaY) = increase, down = decrease
+    /// Horizontal: right (positive deltaX) = increase, left = decrease
+    
+    BOOL isHorizontal = [_drag->type isEqualToString:kMFModifiedDragTypeVolumeHorizontal]
+                     || [_drag->type isEqualToString:kMFModifiedDragTypeBrightnessHorizontal];
+    
+    double delta = isHorizontal ? (deltaX / 400.0) : (-deltaY / 400.0);
+    
+    BOOL isVolume = [_drag->type isEqualToString:kMFModifiedDragTypeVolume]
+                 || [_drag->type isEqualToString:kMFModifiedDragTypeVolumeHorizontal];
+    
+    if (isVolume) {
+        float newVolume = [ScrollOutputUtility getSystemVolume] + (float)delta;
+        [ScrollOutputUtility setSystemVolume:newVolume];
+    } else {
+        [ScrollOutputUtility adjustBrightnessByDelta:(float)delta];
+    }
+}
+
++ (void)handleDeactivationWhileInUseWithCancel:(BOOL)cancel {
+    /// Nothing to clean up
+}
+
++ (void)suspend {
+    /// Nothing to suspend
+}
+
++ (void)unsuspend {
+    /// Nothing to unsuspend
+}
+
+@end

--- a/Helper/Core/Scroll/ScrollModifiers.h
+++ b/Helper/Core/Scroll/ScrollModifiers.h
@@ -23,6 +23,8 @@ typedef enum {
     kMFScrollEffectModificationCommandTab,
     kMFScrollEffectModificationThreeFingerSwipeHorizontal,
     kMFScrollEffectModificationAddModeFeedback,
+    kMFScrollEffectModificationVolume,
+    kMFScrollEffectModificationBrightness,
 } MFScrollEffectModification;
 
 typedef struct {

--- a/Helper/Core/Scroll/ScrollModifiers.swift
+++ b/Helper/Core/Scroll/ScrollModifiers.swift
@@ -95,6 +95,10 @@ extension MFScrollModificationResult: Hashable {
                 result.effectMod = kMFScrollEffectModificationThreeFingerSwipeHorizontal
             case kMFModifiedScrollEffectModificationTypeAddModeFeedback:
                 result.effectMod = kMFScrollEffectModificationAddModeFeedback
+            case kMFModifiedScrollEffectModificationTypeVolume:
+                result.effectMod = kMFScrollEffectModificationVolume
+            case kMFModifiedScrollEffectModificationTypeBrightness:
+                result.effectMod = kMFScrollEffectModificationBrightness
             default:
                 fatalError("Unknown modifiedSrollDict type found in remaps")
             }

--- a/Helper/Core/Scroll/ScrollOutputUtility.h
+++ b/Helper/Core/Scroll/ScrollOutputUtility.h
@@ -1,0 +1,27 @@
+//
+// --------------------------------------------------------------------------
+// ScrollOutputUtility.h
+// Created for Mac Mouse Fix (https://github.com/noah-nuebling/mac-mouse-fix)
+// Licensed under the MMF License (https://github.com/noah-nuebling/mac-mouse-fix/blob/master/License)
+// --------------------------------------------------------------------------
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ScrollOutputUtility : NSObject
+
+/// Volume — CoreAudio scalar, smooth continuous control
++ (float)getSystemVolume;
++ (void)setSystemVolume:(float)volume;
+
+/// Brightness — built-in via DisplayServices, external via DDC/IOAVService
+/// Routes to the display under the mouse pointer automatically
++ (float)getDisplayBrightness;
++ (void)setDisplayBrightness:(float)brightness;   /// absolute (used by scroll)
++ (void)adjustBrightnessByDelta:(float)delta;     /// relative (used by drag)
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Helper/Core/Scroll/ScrollOutputUtility.m
+++ b/Helper/Core/Scroll/ScrollOutputUtility.m
@@ -1,0 +1,330 @@
+//
+// --------------------------------------------------------------------------
+// ScrollOutputUtility.m
+// Created for Mac Mouse Fix (https://github.com/noah-nuebling/mac-mouse-fix)
+// Licensed under the MMF License (https://github.com/noah-nuebling/mac-mouse-fix/blob/master/License)
+// --------------------------------------------------------------------------
+//
+
+#import "ScrollOutputUtility.h"
+#import "Constants.h"
+#import <CoreAudio/CoreAudio.h>
+#import <CoreGraphics/CoreGraphics.h>
+#import <AppKit/AppKit.h>
+#import <IOKit/IOKitLib.h>
+#import <dlfcn.h>
+
+// ─── IOAVService DDC (arm64 external displays) ───────────────────────────────
+
+typedef CFTypeRef IOAVServiceRef;
+typedef IOReturn (*IOAVServiceWriteI2CFunc)(IOAVServiceRef service, uint32_t chipAddress, uint32_t dataAddress, void *buf, uint32_t size);
+typedef IOAVServiceRef (*IOAVServiceCreateWithServiceFunc)(CFAllocatorRef allocator, io_service_t service);
+
+static IOAVServiceWriteI2CFunc        _IOAVServiceWriteI2C        = NULL;
+static IOAVServiceCreateWithServiceFunc _IOAVServiceCreateWithService = NULL;
+
+static void loadIOAVServiceSymbols(void) {
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        void *handle = dlopen("/System/Library/Frameworks/IOKit.framework/IOKit", RTLD_LAZY);
+        if (!handle) handle = RTLD_DEFAULT;
+        _IOAVServiceWriteI2C         = dlsym(handle, "IOAVServiceWriteI2C");
+        _IOAVServiceCreateWithService = dlsym(handle, "IOAVServiceCreateWithService");
+    });
+}
+
+// ─── OSD (private OSD.framework — same HUD as keyboard keys) ─────────────────
+
+static void loadOSDFramework(void) {
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        dlopen("/System/Library/PrivateFrameworks/OSD.framework/OSD", RTLD_LAZY);
+    });
+}
+
+/// OSD image IDs
+typedef NS_ENUM(int64_t, MFOSDImage) {
+    MFOSDImageBrightness    = 1,
+    MFOSDImageVolume        = 3,
+    MFOSDImageVolumeMuted   = 4,
+};
+
+static void showOSD(CGDirectDisplayID displayID, MFOSDImage imageID, float value) {
+    loadOSDFramework();
+    
+    /// Load OSDManager at runtime — it lives in the dyld shared cache, not a linkable stub
+    Class OSDManagerClass = NSClassFromString(@"OSDManager");
+    if (!OSDManagerClass) return;
+    id mgr = [OSDManagerClass performSelector:@selector(sharedManager)];
+    if (!mgr) return;
+    
+    /// 16 chiclets total, same as macOS keyboard HUD
+    uint32_t filled = (uint32_t)roundf(value * 16.0f);
+    filled = MIN(filled, 16);
+    uint32_t total = 16;
+    uint32_t priority = 0x1F4;
+    uint32_t msec = 1000;
+    BOOL locked = NO;
+    
+    /// Use NSInvocation since the method has too many args for performSelector
+    SEL sel = @selector(showImage:onDisplayID:priority:msecUntilFade:filledChiclets:totalChiclets:locked:);
+    NSMethodSignature *sig = [mgr methodSignatureForSelector:sel];
+    if (!sig) return;
+    NSInvocation *inv = [NSInvocation invocationWithMethodSignature:sig];
+    [inv setTarget:mgr];
+    [inv setSelector:sel];
+    [inv setArgument:&imageID      atIndex:2];
+    [inv setArgument:&displayID    atIndex:3];
+    [inv setArgument:&priority     atIndex:4];
+    [inv setArgument:&msec         atIndex:5];
+    [inv setArgument:&filled       atIndex:6];
+    [inv setArgument:&total        atIndex:7];
+    [inv setArgument:&locked       atIndex:8];
+    [inv invoke];
+}
+
+// ─── DisplayServices (built-in display brightness) ───────────────────────────
+
+typedef int (*DisplayServicesGetBrightnessFunc)(CGDirectDisplayID display, float *brightness);
+typedef int (*DisplayServicesSetBrightnessFunc)(CGDirectDisplayID display, float brightness);
+
+static void *displayServicesHandle(void) {
+    static void *handle = NULL;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        handle = dlopen("/System/Library/PrivateFrameworks/DisplayServices.framework/DisplayServices", RTLD_LAZY);
+    });
+    return handle;
+}
+
+// ─── Brightness accumulator (for sub-step scroll deltas) ─────────────────────
+
+static float _brightnessAccumulator = 0.0f;
+
+@implementation ScrollOutputUtility
+
+#pragma mark - Volume (CoreAudio scalar — smooth, no steps)
+
++ (AudioDeviceID)defaultOutputDevice {
+    AudioObjectPropertyAddress addr = {
+        kAudioHardwarePropertyDefaultOutputDevice,
+        kAudioObjectPropertyScopeGlobal,
+        kAudioObjectPropertyElementMain
+    };
+    AudioDeviceID deviceID = kAudioObjectUnknown;
+    UInt32 size = sizeof(deviceID);
+    AudioObjectGetPropertyData(kAudioObjectSystemObject, &addr, 0, NULL, &size, &deviceID);
+    return deviceID;
+}
+
++ (float)getSystemVolume {
+    AudioDeviceID device = [self defaultOutputDevice];
+    if (device == kAudioObjectUnknown) return 0.0f;
+    
+    AudioObjectPropertyAddress addr = {
+        kAudioDevicePropertyVolumeScalar,
+        kAudioDevicePropertyScopeOutput,
+        1 // channel 1 (left)
+    };
+    if (!AudioObjectHasProperty(device, &addr)) {
+        addr.mElement = 0; // master fallback
+        if (!AudioObjectHasProperty(device, &addr)) return 0.0f;
+    }
+    Float32 vol = 0.0f;
+    UInt32 size = sizeof(vol);
+    AudioObjectGetPropertyData(device, &addr, 0, NULL, &size, &vol);
+    return vol;
+}
+
++ (void)setSystemVolume:(float)volume {
+    volume = fmaxf(0.0f, fminf(1.0f, volume));
+    AudioDeviceID device = [self defaultOutputDevice];
+    if (device == kAudioObjectUnknown) return;
+    
+    for (UInt32 ch = 1; ch <= 2; ch++) {
+        AudioObjectPropertyAddress addr = {
+            kAudioDevicePropertyVolumeScalar,
+            kAudioDevicePropertyScopeOutput,
+            ch
+        };
+        if (!AudioObjectHasProperty(device, &addr)) {
+            if (ch == 1) { // try master
+                addr.mElement = 0;
+                if (AudioObjectHasProperty(device, &addr))
+                    AudioObjectSetPropertyData(device, &addr, 0, NULL, sizeof(volume), &volume);
+            }
+            break;
+        }
+        AudioObjectSetPropertyData(device, &addr, 0, NULL, sizeof(volume), &volume);
+    }
+    
+    /// Show volume HUD on the display under the mouse
+    CGDirectDisplayID display = [self displayUnderMouse];
+    showOSD(display, MFOSDImageVolume, volume);
+}
+
+#pragma mark - Display under mouse pointer
+
++ (CGDirectDisplayID)displayUnderMouse {
+    NSPoint mouse = [NSEvent mouseLocation];
+    CGPoint point = CGPointMake(mouse.x, mouse.y);
+    CGDirectDisplayID displayID = kCGNullDirectDisplay;
+    uint32_t count = 0;
+    CGGetDisplaysWithPoint(point, 1, &displayID, &count);
+    if (count == 0) return CGMainDisplayID();
+    return displayID;
+}
+
+#pragma mark - Brightness
+
++ (float)getDisplayBrightness {
+    void *handle = displayServicesHandle();
+    if (!handle) return 0.5f;
+    DisplayServicesGetBrightnessFunc fn = dlsym(handle, "DisplayServicesGetBrightness");
+    if (!fn) return 0.5f;
+    float brightness = 0.5f;
+    fn(CGMainDisplayID(), &brightness); // read from built-in as reference
+    return brightness;
+}
+
++ (void)adjustBrightnessByDelta:(float)delta {
+    /// Accumulate delta and apply in discrete steps.
+    /// Built-in display: DisplayServicesSetBrightness (smooth, continuous).
+    /// External display: DDC VCP 0x10 write via IOAVService (per-monitor, shows HUD in MonitorControl).
+    
+    _brightnessAccumulator += delta;
+    
+    CGDirectDisplayID display = [self displayUnderMouse];
+    BOOL isBuiltIn = CGDisplayIsBuiltin(display);
+    
+    if (isBuiltIn) {
+        /// Built-in: apply continuously via DisplayServices
+        void *handle = displayServicesHandle();
+        if (!handle) return;
+        DisplayServicesGetBrightnessFunc getFn = dlsym(handle, "DisplayServicesGetBrightness");
+        DisplayServicesSetBrightnessFunc setFn = dlsym(handle, "DisplayServicesSetBrightness");
+        if (!getFn || !setFn) return;
+        
+        float current = 0.5f;
+        getFn(display, &current);
+        float newVal = fmaxf(0.0f, fminf(1.0f, current + _brightnessAccumulator));
+        setFn(display, newVal);
+        _brightnessAccumulator = 0.0f;
+        
+        showOSD(display, MFOSDImageBrightness, newVal);
+        
+    } else {
+        /// External: DDC in steps of 1/100 (DDC range 0–100)
+        float step = 1.0f / 100.0f;
+        int steps = 0;
+        while (_brightnessAccumulator >= step)  { steps++;  _brightnessAccumulator -= step; }
+        while (_brightnessAccumulator <= -step) { steps--;  _brightnessAccumulator += step; }
+        if (steps == 0) return;
+        
+        [self writeDDCBrightnessSteps:steps forDisplay:display];
+        /// OSD shown inside writeDDCBrightnessSteps after cache update
+    }
+}
+
++ (void)setDisplayBrightness:(float)brightness {
+    /// Used by scroll output — compute delta from current and apply.
+    float current = [self getDisplayBrightness];
+    [self adjustBrightnessByDelta:brightness - current];
+}
+
+#pragma mark - DDC write (external displays, arm64)
+
++ (void)writeDDCBrightnessSteps:(int)steps forDisplay:(CGDirectDisplayID)displayID {
+    loadIOAVServiceSymbols();
+    if (!_IOAVServiceWriteI2C || !_IOAVServiceCreateWithService) return;
+    
+    /// Find the IOAVService for this display via IORegistry
+    IOAVServiceRef service = [self avServiceForDisplay:displayID];
+    if (!service) return;
+    
+    /// Read current DDC brightness (VCP 0x10), then write new value
+    /// For simplicity we track the value in a static cache keyed by displayID
+    static NSMutableDictionary *brightnessCache = nil;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{ brightnessCache = [NSMutableDictionary dictionary]; });
+    
+    NSNumber *key = @(displayID);
+    int current = brightnessCache[key] ? [brightnessCache[key] intValue] : 50; // default 50%
+    int newVal = MAX(0, MIN(100, current + steps));
+    brightnessCache[key] = @(newVal);
+    
+    /// Show brightness HUD on the external display
+    showOSD(displayID, MFOSDImageBrightness, newVal / 100.0f);
+    
+    /// DDC Set VCP Feature (0x03) packet for VCP code 0x10 (brightness)
+    uint8_t vcpCode = 0x10;
+    uint8_t valHigh = (newVal >> 8) & 0xFF;
+    uint8_t valLow  = newVal & 0xFF;
+    
+    /// Packet: [0x80|len, 0x03, vcpCode, valHigh, valLow, checksum]
+    /// checksum = XOR of (destination<<1) ^ all bytes before checksum
+    uint8_t packet[6];
+    packet[0] = 0x84;       // 0x80 | 4 (payload length)
+    packet[1] = 0x03;       // Set VCP Feature opcode
+    packet[2] = vcpCode;
+    packet[3] = valHigh;
+    packet[4] = valLow;
+    packet[5] = 0x6E ^ packet[0] ^ packet[1] ^ packet[2] ^ packet[3] ^ packet[4]; // 0x6E = 0x37<<1
+    
+    uint32_t chipAddress = 0x37;
+    uint32_t dataAddress = 0x51;
+    
+    /// Copy packet to heap so it can be captured by the block
+    NSData *packetData = [NSData dataWithBytes:packet length:sizeof(packet)];
+    
+    dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INTERACTIVE, 0), ^{
+        _IOAVServiceWriteI2C(service, chipAddress, dataAddress, (void *)packetData.bytes, (uint32_t)packetData.length);
+        CFRelease(service);
+    });
+}
+
++ (IOAVServiceRef)avServiceForDisplay:(CGDirectDisplayID)displayID {
+    loadIOAVServiceSymbols();
+    if (!_IOAVServiceCreateWithService) return NULL;
+    
+    BOOL isBuiltIn = CGDisplayIsBuiltin(displayID);
+    NSString *targetLocation = isBuiltIn ? @"Embedded" : @"External";
+    
+    /// On Apple Silicon, displays use DCPAVServiceProxy instead of IOAVService.
+    /// Match by Location property ("Embedded" for built-in, "External" for external).
+    const char *classes[] = { "DCPAVServiceProxy", "IOAVService", NULL };
+    
+    for (int i = 0; classes[i] != NULL; i++) {
+        io_iterator_t iter = IO_OBJECT_NULL;
+        IOServiceGetMatchingServices(kIOMainPortDefault,
+                                     IOServiceMatching(classes[i]),
+                                     &iter);
+        io_service_t entry;
+        while ((entry = IOIteratorNext(iter)) != IO_OBJECT_NULL) {
+            CFMutableDictionaryRef props = NULL;
+            IORegistryEntryCreateCFProperties(entry, &props, kCFAllocatorDefault, 0);
+            
+            BOOL locationMatch = NO;
+            if (props) {
+                CFStringRef location = CFDictionaryGetValue(props, CFSTR("Location"));
+                if (location) {
+                    NSString *loc = (__bridge NSString *)location;
+                    locationMatch = [loc isEqualToString:targetLocation];
+                }
+                CFRelease(props);
+            }
+            
+            if (locationMatch) {
+                IOAVServiceRef service = _IOAVServiceCreateWithService(kCFAllocatorDefault, entry);
+                IOObjectRelease(entry);
+                IOObjectRelease(iter);
+                return service;
+            }
+            IOObjectRelease(entry);
+        }
+        IOObjectRelease(iter);
+    }
+    return NULL;
+}
+
+@end

--- a/Mouse Fix.xcodeproj/project.pbxproj
+++ b/Mouse Fix.xcodeproj/project.pbxproj
@@ -324,6 +324,9 @@
 		4FF6668F25F2C93A00689B77 /* SmoothScroll_old_.m in Sources */ = {isa = PBXBuildFile; fileRef = 4FF6662D25F2C93A00689B77 /* SmoothScroll_old_.m */; };
 		4FF6669025F2C93A00689B77 /* ScrollModifiers_old_.m in Sources */ = {isa = PBXBuildFile; fileRef = 4FF6662E25F2C93A00689B77 /* ScrollModifiers_old_.m */; };
 		4FF6669125F2C93A00689B77 /* ScrollUtility.m in Sources */ = {isa = PBXBuildFile; fileRef = 4FF6662F25F2C93A00689B77 /* ScrollUtility.m */; };
+		BB000001000000000000BB03 /* LogitechCIDActivator.m in Sources */ = {isa = PBXBuildFile; fileRef = BB000001000000000000BB02 /* LogitechCIDActivator.m */; };
+		AA000001000000000000AA03 /* ScrollOutputUtility.m in Sources */ = {isa = PBXBuildFile; fileRef = AA000001000000000000AA02 /* ScrollOutputUtility.m */; };
+		AA000001000000000000AA06 /* ModifiedDragOutputVolumeBrightness.m in Sources */ = {isa = PBXBuildFile; fileRef = AA000001000000000000AA05 /* ModifiedDragOutputVolumeBrightness.m */; };
 		4FF6669225F2C93A00689B77 /* RoughScroll_old_.m in Sources */ = {isa = PBXBuildFile; fileRef = 4FF6663025F2C93A00689B77 /* RoughScroll_old_.m */; };
 		4FF6669325F2C93A00689B77 /* TouchSimulator.m in Sources */ = {isa = PBXBuildFile; fileRef = 4FF6663325F2C93A00689B77 /* TouchSimulator.m */; };
 		4FF6669525F2C93A00689B77 /* ModifiedDrag.m in Sources */ = {isa = PBXBuildFile; fileRef = 4FF6663825F2C93A00689B77 /* ModifiedDrag.m */; };
@@ -2399,6 +2402,12 @@
 		4FF6662D25F2C93A00689B77 /* SmoothScroll_old_.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SmoothScroll_old_.m; sourceTree = "<group>"; };
 		4FF6662E25F2C93A00689B77 /* ScrollModifiers_old_.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ScrollModifiers_old_.m; sourceTree = "<group>"; };
 		4FF6662F25F2C93A00689B77 /* ScrollUtility.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ScrollUtility.m; sourceTree = "<group>"; };
+		BB000001000000000000BB01 /* LogitechCIDActivator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LogitechCIDActivator.h; sourceTree = "<group>"; };
+		BB000001000000000000BB02 /* LogitechCIDActivator.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = LogitechCIDActivator.m; sourceTree = "<group>"; };
+		AA000001000000000000AA01 /* ScrollOutputUtility.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ScrollOutputUtility.h; sourceTree = "<group>"; };
+		AA000001000000000000AA02 /* ScrollOutputUtility.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ScrollOutputUtility.m; sourceTree = "<group>"; };
+		AA000001000000000000AA04 /* ModifiedDragOutputVolumeBrightness.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ModifiedDragOutputVolumeBrightness.h; sourceTree = "<group>"; };
+		AA000001000000000000AA05 /* ModifiedDragOutputVolumeBrightness.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ModifiedDragOutputVolumeBrightness.m; sourceTree = "<group>"; };
 		4FF6663025F2C93A00689B77 /* RoughScroll_old_.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RoughScroll_old_.m; sourceTree = "<group>"; };
 		4FF6663225F2C93A00689B77 /* GestureScrollSimulator_old_.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GestureScrollSimulator_old_.h; sourceTree = "<group>"; };
 		4FF6663325F2C93A00689B77 /* TouchSimulator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TouchSimulator.m; sourceTree = "<group>"; };
@@ -7427,6 +7436,8 @@
 			children = (
 				4FF6661B25F2C93A00689B77 /* ButtonInputReceiver.h */,
 				4FF6661E25F2C93A00689B77 /* ButtonInputReceiver.m */,
+					BB000001000000000000BB01 /* LogitechCIDActivator.h */,
+					BB000001000000000000BB02 /* LogitechCIDActivator.m */,
 				4FF8C8A22895AACB007EC31F /* Buttons.swift */,
 				4FF8C89928955490007EC31F /* ClickCycle.swift */,
 				4FE479DF2933C87A00B75E9B /* ButtonModifiers.h */,
@@ -7452,6 +7463,8 @@
 				4F5F3EF22756F1DB00C350C0 /* ScrollModifiers.swift */,
 				4FF6662B25F2C93A00689B77 /* ScrollUtility.h */,
 				4FF6662F25F2C93A00689B77 /* ScrollUtility.m */,
+					AA000001000000000000AA01 /* ScrollOutputUtility.h */,
+					AA000001000000000000AA02 /* ScrollOutputUtility.m */,
 				4FF6662225F2C93A00689B77 /* Unused */,
 				4F3CDB272837D889000E28F0 /* ScrollNotes.md */,
 			);
@@ -7493,6 +7506,8 @@
 			children = (
 				4FF6663725F2C93A00689B77 /* ModifiedDrag.h */,
 				4FF6663825F2C93A00689B77 /* ModifiedDrag.m */,
+					AA000001000000000000AA04 /* ModifiedDragOutputVolumeBrightness.h */,
+					AA000001000000000000AA05 /* ModifiedDragOutputVolumeBrightness.m */,
 				4FCB260D293147CD0066EE56 /* ModifiedDrag.swift */,
 				4FF0255827B00F9700923107 /* ThreeFingerSwipe */,
 				4FF0255927B00FA400923107 /* TwoFingerSwipe */,
@@ -8274,6 +8289,9 @@
 				4FF6668125F2C93A00689B77 /* FileMonitor.m in Sources */,
 				4F1AFE972670EBA900ECA424 /* DragCurve.swift in Sources */,
 				4FF6669125F2C93A00689B77 /* ScrollUtility.m in Sources */,
+					BB000001000000000000BB03 /* LogitechCIDActivator.m in Sources */,
+					AA000001000000000000AA03 /* ScrollOutputUtility.m in Sources */,
+					AA000001000000000000AA06 /* ModifiedDragOutputVolumeBrightness.m in Sources */,
 				4FB8B29B2CCEBAEB00A5A580 /* GetLicenseConfig.swift in Sources */,
 				4F1B41902D49960E00026C94 /* MFSemaphore.m in Sources */,
 				4FF666A825F2C93A00689B77 /* DeviceManager.m in Sources */,
@@ -8480,7 +8498,7 @@
 				MARKETING_VERSION = 3.0.8;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.nuebling.mac-mouse-fix";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.virgoh.mac-mouse-fix";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) IS_MAIN_APP";
@@ -8517,7 +8535,7 @@
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				MARKETING_VERSION = 3.0.8;
 				MTL_FAST_MATH = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.nuebling.mac-mouse-fix";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.virgoh.mac-mouse-fix";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) IS_MAIN_APP";
@@ -8798,7 +8816,7 @@
 				INFOPLIST_FILE = Helper/SupportFiles/Info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.nuebling.mac-mouse-fix.helper";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.virgoh.mac-mouse-fix.helper";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
@@ -8839,7 +8857,7 @@
 				INFOPLIST_FILE = Helper/SupportFiles/Info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.nuebling.mac-mouse-fix.helper";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.virgoh.mac-mouse-fix.helper";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;

--- a/Shared/Constants.h
+++ b/Shared/Constants.h
@@ -141,6 +141,10 @@ typedef NSString*                                                       MFString
 #define kMFModifiedDragTypeThreeFingerSwipe                             @"threeFingerSwipe"
 #define kMFModifiedDragTypeFakeDrag                                     @"fakeDrag"
 #define kMFModifiedDragTypeAddModeFeedback                              @"addModeDrag"
+#define kMFModifiedDragTypeVolume                                       @"volume"
+#define kMFModifiedDragTypeBrightness                                   @"brightness"
+#define kMFModifiedDragTypeVolumeHorizontal                             @"volumeHorizontal"
+#define kMFModifiedDragTypeBrightnessHorizontal                         @"brightnessHorizontal"
 // Variant keys
 #define kMFModifiedDragDictKeyFakeDragVariantButtonNumber               @"buttonNumber"
 
@@ -161,6 +165,8 @@ typedef NSString*                                                       MFString
 #define kMFModifiedScrollEffectModificationTypeRotate                                       @"rotate"
 #define kMFModifiedScrollEffectModificationTypeCommandTab                                   @"commandTab"
 #define kMFModifiedScrollEffectModificationTypeAddModeFeedback                              @"addModeScroll"
+#define kMFModifiedScrollEffectModificationTypeVolume                                       @"volume"
+#define kMFModifiedScrollEffectModificationTypeBrightness                                   @"brightness"
 
 // Oneshot Actions
 // TODO: Used to be named ActionDict... Rename to OneShot..., or OneShotDict

--- a/Shared/Devices/DeviceManager.m
+++ b/Shared/Devices/DeviceManager.m
@@ -32,6 +32,7 @@
 
 #import "SharedUtility.h"
 #import "Mac_Mouse_Fix_Helper-Swift.h"
+#import "LogitechCIDActivator.h"
 
 @implementation DeviceManager
 
@@ -267,6 +268,9 @@ static void handleDeviceMatching(void *context, IOReturn result, void *sender, I
         
     #endif
         
+        /// Activate Logitech HID++ CID diversion for extra buttons
+        [[LogitechCIDActivator shared] handleDeviceAttached: device];
+
         /// Log
         DDLogInfo(@"New device added to attached devices:\n%@", newDevice);
         
@@ -307,6 +311,9 @@ static void handleDeviceRemoval(void *context, IOReturn result, void *sender, IO
 //        [Scroll decide];
 //        [ButtonInputReceiver decide];
         
+        /// Clean up Logitech CID diversion
+        [[LogitechCIDActivator shared] handleDeviceRemoved: device];
+
         /// Log
         
         DDLogInfo(@"Attached device was removed:\n%@", attachedDevice);


### PR DESCRIPTION
## Summary

Adds system volume and display brightness as scroll effect modifications and drag output plugins. Users can assign volume/brightness control to any button+scroll or button+drag combination.

## Features

- **Volume**: Smooth CoreAudio scalar API (continuous 0.0–1.0, no discrete steps)
- **Brightness (built-in display)**: DisplayServices private framework (continuous)
- **Brightness (external display)**: DDC/CI via IOAVServiceWriteI2C on Apple Silicon (DCPAVServiceProxy)
- **Per-monitor targeting**: Brightness targets the display under the mouse pointer
- **OSD HUD**: Native macOS bezel (volume/brightness chiclets) via private OSD.framework
- **Drag variants**: Vertical and horizontal mouse movement for both controls
- **Scroll variants**: Scroll wheel for both controls

## New files

- `Helper/Core/Scroll/ScrollOutputUtility.h/.m` — CoreAudio, DisplayServices, DDC, OSD integration
- `Helper/Core/Drag/ModifiedDragOutputVolumeBrightness.h/.m` — drag output plugin

## Modified files

- `Shared/Constants.h` — new type constants
- `Helper/Core/Scroll/ScrollModifiers.h/.swift` — new effect modification enums
- `Helper/Core/Scroll/Scroll.m` — new output types
- `Helper/Core/Config/ScrollConfig.swift` — disable animation for volume/brightness
- `Helper/Core/Drag/ModifiedDrag.m` — register new drag plugin
- `App/UI/Main/Tabs/ButtonTab/RemapTable/RemapTableTranslator.m` — UI menu entries
- `Mouse Fix.xcodeproj/project.pbxproj` — new file references

## Testing

Tested on M2 Max MacBook Pro with Samsung LU28R55 external monitor. Volume OSD appears on the display under the cursor. Brightness works on both built-in (DisplayServices) and external (DDC) displays.