### PR TITLE
Add Rotate and Zoom as drag effects

### DIFF
--- a/App/UI/Main/Tabs/ButtonTab/RemapTable/RemapTableTranslator.m
+++ b/App/UI/Main/Tabs/ButtonTab/RemapTable/RemapTableTranslator.m
@@ -114,6 +114,13 @@ static NSArray *getDragEffectsTable() {
         @{@"ui": NSLocalizedString(@"drag-effect.scroll-swipe", @"First draft: Scroll & Navigate"), @"tool": NSLocalizedString(@"drag-effect.scroll-swipe.hint", @"First draft: Scroll freely by moving your mouse in any direction\n \nAlso Navigate between pages in Safari, delete messages in Mail and more by moving your mouse left and right\n \nWorks like swiping with 2 fingers on an Apple Trackpad") , @"dict": @{
                   kMFModifiedDragDictKeyType: kMFModifiedDragTypeTwoFingerSwipe,
         }},
+        separatorEffectsTableEntry(),
+        @{@"ui": NSLocalizedString(@"drag-effect.rotate", @"Rotate"), @"tool": NSLocalizedString(@"drag-effect.rotate.hint", @"Rotate content in Apple Maps and other apps by moving your mouse left and right\n \nWorks like twisting with 2 fingers on an Apple Trackpad"), @"dict": @{
+                  kMFModifiedDragDictKeyType: kMFModifiedDragTypeRotate,
+        }},
+        @{@"ui": NSLocalizedString(@"drag-effect.zoom", @"Zoom In or Out"), @"tool": NSLocalizedString(@"drag-effect.zoom.hint", @"Zoom in or out by moving your mouse up and down\n \nWorks like pinching with 2 fingers on an Apple Trackpad"), @"dict": @{
+                  kMFModifiedDragDictKeyType: kMFModifiedDragTypeZoom,
+        }},
 //        separatorEffectsTableEntry(),
 //        @{
 ////          @"ui": [NSString stringWithFormat:@"%@ Click and Drag", [UIStrings getButtonString:3]],

--- a/Helper/Core/Buttons/LogitechCIDActivator.h
+++ b/Helper/Core/Buttons/LogitechCIDActivator.h
@@ -1,0 +1,34 @@
+//
+// --------------------------------------------------------------------------
+// LogitechCIDActivator.h
+// Created for Mac Mouse Fix (https://github.com/noah-nuebling/mac-mouse-fix)
+// Created by Miguel Angelo in 2026
+// Licensed under the MMF License (https://github.com/noah-nuebling/mac-mouse-fix/blob/master/License)
+// --------------------------------------------------------------------------
+//
+// Activates Logitech HID++ 2.0 ReprogControlsV4 (feature 0x1B04) on attached
+// Logitech devices so that extra buttons (thumb, tilt wheel, precision, side
+// buttons) are diverted and reported as standard CGEvent mouse buttons that
+// Mac Mouse Fix can remap.
+//
+// References:
+//   - Solaar (pwr-Solaar/Solaar) hidpp20.py — flag byte "valid bit" pattern
+//   - libratbag hidpp20.c — TID definitions and GetCidInfo parsing
+//   - https://lekensteyn.nl/files/logitech/x1b04_specialkeysmsebuttons.html
+//
+
+#import <Foundation/Foundation.h>
+#import <IOKit/hid/IOHIDDevice.h>
+
+@interface LogitechCIDActivator : NSObject
+
++ (instancetype)shared;
+
+/// Call when a new device is attached. Activates CID diversion if the device
+/// is a Logitech mouse with ReprogControlsV4 support.
+- (void)handleDeviceAttached: (IOHIDDeviceRef)device;
+
+/// Call when a device is removed. Cleans up state for that device.
+- (void)handleDeviceRemoved: (IOHIDDeviceRef)device;
+
+@end

--- a/Helper/Core/Buttons/LogitechCIDActivator.m
+++ b/Helper/Core/Buttons/LogitechCIDActivator.m
@@ -1,0 +1,218 @@
+//
+// --------------------------------------------------------------------------
+// LogitechCIDActivator.m
+// Created for Mac Mouse Fix (https://github.com/noah-nuebling/mac-mouse-fix)
+// Created by Miguel Angelo in 2026
+// Licensed under the MMF License (https://github.com/noah-nuebling/mac-mouse-fix/blob/master/License)
+// --------------------------------------------------------------------------
+
+#import "LogitechCIDActivator.h"
+#import <IOKit/hid/IOHIDLib.h>
+#import <CoreGraphics/CoreGraphics.h>
+#import <AppKit/AppKit.h>
+#import "SharedUtility.h"
+#import "Mac_Mouse_Fix_Helper-Swift.h"
+#import "DeviceManager.h"
+
+#define kLogitechVID    0x046D
+#define kHIDPP_Long     0x11
+#define kHIDPP_Device   0xFF
+#define kFeat_ReprogV4  0x1B04
+
+/// SetCidReporting flags — Solaar hidpp20.py "valid bit" pattern:
+///   each flag bit has a corresponding valid bit = flag << 1
+///   0x03 = divert=1 (bit0) + divert_valid=1 (bit1)
+#define kDivertFlags    0x03
+
+/// TIDs of controls that already report natively — must NOT be diverted
+///   0x0038=left, 0x0039=right, 0x003A=middle, 0x003C=back, 0x003E=forward
+static const uint16_t kNativeTIDs[] = { 0x0038, 0x0039, 0x003A, 0x003C, 0x003E };
+
+/// CGEvent button numbers are 0-based. 5 = MMF "button 6" (first above L/R/M/Back/Fwd)
+#define kFirstCGButton  6
+
+typedef struct {
+    IOHIDDeviceRef  device;
+    uint8_t         reportBuf[64];
+    uint16_t        cidMap[32];
+    int             cidCount;
+    uint16_t        pressedCIDs[32];
+    int             pressedCount;
+} MFCIDDeviceState;
+
+static uint8_t sResp[20];
+static BOOL    sGotResp = NO;
+
+static BOOL isNativeTID(uint16_t tid) {
+    for (int i = 0; i < 5; i++) if (kNativeTIDs[i] == tid) return YES;
+    return NO;
+}
+
+static int buttonForCID(MFCIDDeviceState *s, uint16_t cid) {
+    for (int i = 0; i < s->cidCount; i++)
+        if (s->cidMap[i] == cid) return kFirstCGButton + i;
+    if (s->cidCount < 32) { s->cidMap[s->cidCount++] = cid; return kFirstCGButton + s->cidCount - 1; }
+    return kFirstCGButton;
+}
+
+static void injectButton(MFCIDDeviceState *s, uint16_t cid, BOOL down) {
+    int btn = buttonForCID(s, cid);
+    Device *device = [DeviceManager attachedDeviceWithIOHIDDevice: s->device];
+    if (!device) device = [Device strangeDevice];
+    CGEventRef event = CGEventCreate(NULL);
+    [Buttons handleInputWithDevice: device button: @(btn) downNotUp: down event: event];
+    CFRelease(event);
+}
+
+static void inputReportCallback(void *ctx, IOReturn result, void *sender,
+                                IOHIDReportType type, uint32_t reportID,
+                                uint8_t *report, CFIndex len) {
+    if (len < 5 || report[0] != kHIDPP_Long) return;
+    MFCIDDeviceState *s = (MFCIDDeviceState *)ctx;
+    if (report[3] != 0x00) {
+        memcpy(sResp, report, len < 20 ? (size_t)len : 20);
+        sGotResp = YES;
+        return;
+    }
+    uint16_t cid = ((uint16_t)report[4] << 8) | report[5];
+    if (cid == 0) {
+        for (int i = 0; i < s->pressedCount; i++) injectButton(s, s->pressedCIDs[i], NO);
+        s->pressedCount = 0;
+    } else {
+        for (int i = 0; i < s->pressedCount; i++) if (s->pressedCIDs[i] == cid) return;
+        injectButton(s, cid, YES);
+        if (s->pressedCount < 32) s->pressedCIDs[s->pressedCount++] = cid;
+    }
+}
+
+static IOReturn sendAndWait(IOHIDDeviceRef dev, uint8_t *pkt) {
+    sGotResp = NO;
+    IOReturn r = IOHIDDeviceSetReport(dev, kIOHIDReportTypeOutput, pkt[0], pkt, 20);
+    if (r != kIOReturnSuccess) return r;
+    for (int i = 0; i < 100 && !sGotResp; i++) CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.01, false);
+    if (!sGotResp) return kIOReturnTimeout;
+    if (sResp[2] == 0xFF) return kIOReturnError;
+    return kIOReturnSuccess;
+}
+
+static int activateDevice(IOHIDDeviceRef dev, MFCIDDeviceState *s) {
+    uint8_t pkt[20];
+
+    /// 1. GetFeature(0x1B04)
+    memset(pkt, 0, 20);
+    pkt[0]=kHIDPP_Long; pkt[1]=kHIDPP_Device; pkt[2]=0x00; pkt[3]=0x0E;
+    pkt[4]=(kFeat_ReprogV4>>8)&0xFF; pkt[5]=kFeat_ReprogV4&0xFF;
+    if (sendAndWait(dev, pkt) != kIOReturnSuccess || sResp[4] == 0) return 0;
+    uint8_t feat = sResp[4];
+
+    /// 2. GetCount
+    memset(pkt, 0, 20);
+    pkt[0]=kHIDPP_Long; pkt[1]=kHIDPP_Device; pkt[2]=feat; pkt[3]=0x0E;
+    if (sendAndWait(dev, pkt) != kIOReturnSuccess) return 0;
+    int count = sResp[4];
+
+    /// 3. GetCidInfo — collect divertable CIDs
+    uint16_t todivert[32]; int ndiv = 0;
+    for (int i = 0; i < count && ndiv < 32; i++) {
+        memset(pkt, 0, 20);
+        pkt[0]=kHIDPP_Long; pkt[1]=kHIDPP_Device; pkt[2]=feat; pkt[3]=0x1E; pkt[4]=(uint8_t)i;
+        if (sendAndWait(dev, pkt) != kIOReturnSuccess) continue;
+        uint16_t cid = ((uint16_t)sResp[4]<<8)|sResp[5];
+        uint16_t tid = ((uint16_t)sResp[6]<<8)|sResp[7];
+        uint8_t flags = sResp[8];
+        if ((flags & (1<<4)) && !isNativeTID(tid)) todivert[ndiv++] = cid;
+    }
+
+    /// 4. Pre-register button mapping for stable numbering
+    for (int i = 0; i < ndiv; i++) buttonForCID(s, todivert[i]);
+
+    /// 5. SetCidReporting — divert
+    int diverted = 0;
+    for (int i = 0; i < ndiv; i++) {
+        memset(pkt, 0, 20);
+        pkt[0]=kHIDPP_Long; pkt[1]=kHIDPP_Device; pkt[2]=feat; pkt[3]=0x3E;
+        pkt[4]=(todivert[i]>>8)&0xFF; pkt[5]=todivert[i]&0xFF; pkt[6]=kDivertFlags;
+        if (sendAndWait(dev, pkt) == kIOReturnSuccess) diverted++;
+    }
+    return diverted;
+}
+
+@interface LogitechCIDActivator ()
+@property (nonatomic) NSMutableArray *states;
+@property (nonatomic) NSTimer *reactivateTimer;
+@end
+
+@implementation LogitechCIDActivator
+
++ (instancetype)shared {
+    static LogitechCIDActivator *instance = nil;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{ instance = [self new]; });
+    return instance;
+}
+
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        _states = [NSMutableArray array];
+        /// Re-activate on system wake — firmware clears divert state on sleep
+        [[[NSWorkspace sharedWorkspace] notificationCenter]
+            addObserver: self
+               selector: @selector(reactivateAll)
+                   name: NSWorkspaceDidWakeNotification
+                 object: nil];
+        /// Periodic safety net — covers firmware timeout without sleep/wake cycle
+        _reactivateTimer = [NSTimer scheduledTimerWithTimeInterval: 60 * 30
+                                                           target: self
+                                                         selector: @selector(reactivateAll)
+                                                         userInfo: nil
+                                                          repeats: YES];
+    }
+    return self;
+}
+
+- (void)reactivateAll {
+    for (NSValue *v in _states) {
+        MFCIDDeviceState *s = (MFCIDDeviceState *)v.pointerValue;
+        activateDevice(s->device, s);
+    }
+    DDLogDebug(@"LogitechCIDActivator: re-activated %lu device(s)", (unsigned long)_states.count);
+}
+
+- (void)handleDeviceAttached: (IOHIDDeviceRef)device {
+    NSNumber *vid = (__bridge NSNumber *)IOHIDDeviceGetProperty(device, CFSTR(kIOHIDVendorIDKey));
+    if (vid.integerValue != kLogitechVID) return;
+    if (IOHIDDeviceOpen(device, kIOHIDOptionsTypeNone) != kIOReturnSuccess) return;
+
+    MFCIDDeviceState *s = calloc(1, sizeof(MFCIDDeviceState));
+    s->device = device;
+    IOHIDDeviceRegisterInputReportCallback(device, s->reportBuf, sizeof(s->reportBuf), inputReportCallback, s);
+    IOHIDDeviceScheduleWithRunLoop(device, CFRunLoopGetMain(), kCFRunLoopDefaultMode);
+
+    int diverted = activateDevice(device, s);
+    if (diverted > 0) {
+        NSString *name = (__bridge NSString *)IOHIDDeviceGetProperty(device, CFSTR(kIOHIDProductKey));
+        DDLogInfo(@"LogitechCIDActivator: diverted %d CIDs on '%@'", diverted, name);
+        [_states addObject: [NSValue valueWithPointer: s]];
+    } else {
+        IOHIDDeviceUnscheduleFromRunLoop(device, CFRunLoopGetMain(), kCFRunLoopDefaultMode);
+        IOHIDDeviceClose(device, kIOHIDOptionsTypeNone);
+        free(s);
+    }
+}
+
+- (void)handleDeviceRemoved: (IOHIDDeviceRef)device {
+    NSValue *found = nil;
+    for (NSValue *v in _states) {
+        if (((MFCIDDeviceState *)v.pointerValue)->device == device) { found = v; break; }
+    }
+    if (!found) return;
+    MFCIDDeviceState *s = (MFCIDDeviceState *)found.pointerValue;
+    for (int i = 0; i < s->pressedCount; i++) injectButton(s, s->pressedCIDs[i], NO);
+    IOHIDDeviceUnscheduleFromRunLoop(device, CFRunLoopGetMain(), kCFRunLoopDefaultMode);
+    IOHIDDeviceClose(device, kIOHIDOptionsTypeNone);
+    free(s);
+    [_states removeObject: found];
+}
+
+@end

--- a/Helper/Core/Drag/ModifiedDrag.m
+++ b/Helper/Core/Drag/ModifiedDrag.m
@@ -31,6 +31,7 @@
 #import "ModifiedDragOutputTwoFingerSwipe.h"
 #import "ModifiedDragOutputFakeDrag.h"
 #import "ModifiedDragOutputAddMode.h"
+#import "ModifiedDragOutputRotateZoom.h"
 
 #import "GlobalEventTapThread.h"
 
@@ -170,6 +171,10 @@ static ModifiedDragState _drag;
             p = (id<ModifiedDragOutputPlugin>)ModifiedDragOutputFakeDrag.class;
         } else if ([type isEqualToString:kMFModifiedDragTypeAddModeFeedback]) {
             p = (id<ModifiedDragOutputPlugin>)ModifiedDragOutputAddMode.class;
+        } else if ([type isEqualToString:kMFModifiedDragTypeRotate]) {
+            p = (id<ModifiedDragOutputPlugin>)ModifiedDragOutputRotateZoom.class;
+        } else if ([type isEqualToString:kMFModifiedDragTypeZoom]) {
+            p = (id<ModifiedDragOutputPlugin>)ModifiedDragOutputRotateZoom.class;
         } else {
             assert(false);
         }

--- a/Helper/Core/Drag/ModifiedDragOutputRotateZoom.h
+++ b/Helper/Core/Drag/ModifiedDragOutputRotateZoom.h
@@ -1,0 +1,19 @@
+//
+// --------------------------------------------------------------------------
+// ModifiedDragOutputRotateZoom.h
+// Created for Mac Mouse Fix (https://github.com/noah-nuebling/mac-mouse-fix)
+// Licensed under the MMF License (https://github.com/noah-nuebling/mac-mouse-fix/blob/master/License)
+// --------------------------------------------------------------------------
+//
+
+#import <Foundation/Foundation.h>
+#import "ModifiedDrag.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Handles both rotate (horizontal drag) and zoom (vertical drag) as drag output plugins.
+@interface ModifiedDragOutputRotateZoom : NSObject <ModifiedDragOutputPlugin>
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Helper/Core/Drag/ModifiedDragOutputRotateZoom.m
+++ b/Helper/Core/Drag/ModifiedDragOutputRotateZoom.m
@@ -1,0 +1,73 @@
+//
+// --------------------------------------------------------------------------
+// ModifiedDragOutputRotateZoom.m
+// Created for Mac Mouse Fix (https://github.com/noah-nuebling/mac-mouse-fix)
+// Licensed under the MMF License (https://github.com/noah-nuebling/mac-mouse-fix/blob/master/License)
+// --------------------------------------------------------------------------
+//
+
+#import "ModifiedDragOutputRotateZoom.h"
+#import "TouchSimulator.h"
+#import "Constants.h"
+#import "IOHIDEventTypes.h"
+
+@implementation ModifiedDragOutputRotateZoom
+
+#pragma mark - Vars
+
+static ModifiedDragState *_drag;
+static BOOL _isFirstCallback;
+
+#pragma mark - Interface
+
++ (void)initializeWithDragState:(ModifiedDragState *)dragStateRef {
+    _drag = dragStateRef;
+    _isFirstCallback = YES;
+}
+
++ (void)handleBecameInUse {
+    _isFirstCallback = YES;
+}
+
++ (void)handleMouseInputWhileInUseWithDeltaX:(double)deltaX deltaY:(double)deltaY event:(CGEventRef)event {
+    
+    IOHIDEventPhaseBits phase = _isFirstCallback ? kIOHIDEventPhaseBegan : kIOHIDEventPhaseChanged;
+    _isFirstCallback = NO;
+    
+    BOOL isRotate = [_drag->type isEqualToString:kMFModifiedDragTypeRotate];
+    
+    if (isRotate) {
+        /// Horizontal mouse movement → rotation
+        /// Scale: ~400px = full 360° rotation (but in practice small movements are used)
+        double rotation = deltaX / 8.0;
+        [TouchSimulator postRotationEventWithRotation:rotation phase:phase];
+    } else {
+        /// Vertical mouse movement → zoom (pinch)
+        /// Moving up (negative deltaY) = zoom in, moving down = zoom out
+        double magnification = -deltaY / 400.0;
+        [TouchSimulator postMagnificationEventWithMagnification:magnification phase:phase];
+    }
+}
+
++ (void)handleDeactivationWhileInUseWithCancel:(BOOL)cancel {
+    
+    IOHIDEventPhaseBits endPhase = cancel ? kIOHIDEventPhaseCancelled : kIOHIDEventPhaseEnded;
+    
+    BOOL isRotate = [_drag->type isEqualToString:kMFModifiedDragTypeRotate];
+    
+    if (isRotate) {
+        [TouchSimulator postRotationEventWithRotation:0 phase:endPhase];
+    } else {
+        [TouchSimulator postMagnificationEventWithMagnification:0 phase:endPhase];
+    }
+    
+    _isFirstCallback = YES;
+}
+
++ (void)suspend {
+}
+
++ (void)unsuspend {
+}
+
+@end

--- a/Localization/en.lproj/Localizable.strings
+++ b/Localization/en.lproj/Localizable.strings
@@ -562,3 +562,9 @@
 
 /* First draft: Type a Keyboard Shortcut */
 "type-shortcut-prompt" = "Type a Keyboard Shortcut";
+
+/* Rotate and zoom drag effects */
+"drag-effect.rotate" = "Rotate";
+"drag-effect.rotate.hint" = "Rotate content in Apple Maps and other apps by moving your mouse left and right\n \nWorks like twisting with 2 fingers on an Apple Trackpad";
+"drag-effect.zoom" = "Zoom In or Out";
+"drag-effect.zoom.hint" = "Zoom in or out by moving your mouse up and down\n \nWorks like pinching with 2 fingers on an Apple Trackpad";

--- a/Mouse Fix.xcodeproj/project.pbxproj
+++ b/Mouse Fix.xcodeproj/project.pbxproj
@@ -282,6 +282,7 @@
 		4FF0255127B0033000923107 /* ModifiedDragOutputTwoFingerSwipe.m in Sources */ = {isa = PBXBuildFile; fileRef = 4FF0255027B0033000923107 /* ModifiedDragOutputTwoFingerSwipe.m */; };
 		4FF0255427B007FC00923107 /* ModifiedDragOutputFakeDrag.m in Sources */ = {isa = PBXBuildFile; fileRef = 4FF0255327B007FC00923107 /* ModifiedDragOutputFakeDrag.m */; };
 		4FF0255727B0091700923107 /* ModifiedDragOutputAddMode.m in Sources */ = {isa = PBXBuildFile; fileRef = 4FF0255627B0091700923107 /* ModifiedDragOutputAddMode.m */; };
+		DD000001000000000000DD03 /* ModifiedDragOutputRotateZoom.m in Sources */ = {isa = PBXBuildFile; fileRef = DD000001000000000000DD02 /* ModifiedDragOutputRotateZoom.m */; };
 		4FF0255F27B013A100923107 /* PointerFreeze.m in Sources */ = {isa = PBXBuildFile; fileRef = 4FF0255E27B013A100923107 /* PointerFreeze.m */; };
 		4FF0BD4B266A8B7E003935EA /* Bezier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FF0BD4A266A8B7E003935EA /* Bezier.swift */; };
 		4FF0BD51266AC10C003935EA /* Math.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FF0BD50266AC10C003935EA /* Math.swift */; };
@@ -2328,6 +2329,8 @@
 		4FF0255327B007FC00923107 /* ModifiedDragOutputFakeDrag.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ModifiedDragOutputFakeDrag.m; sourceTree = "<group>"; };
 		4FF0255527B0091700923107 /* ModifiedDragOutputAddMode.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ModifiedDragOutputAddMode.h; sourceTree = "<group>"; };
 		4FF0255627B0091700923107 /* ModifiedDragOutputAddMode.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ModifiedDragOutputAddMode.m; sourceTree = "<group>"; };
+		DD000001000000000000DD01 /* ModifiedDragOutputRotateZoom.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ModifiedDragOutputRotateZoom.h; sourceTree = "<group>"; };
+		DD000001000000000000DD02 /* ModifiedDragOutputRotateZoom.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ModifiedDragOutputRotateZoom.m; sourceTree = "<group>"; };
 		4FF0255D27B013A100923107 /* PointerFreeze.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PointerFreeze.h; sourceTree = "<group>"; };
 		4FF0255E27B013A100923107 /* PointerFreeze.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PointerFreeze.m; sourceTree = "<group>"; };
 		4FF0BD4A266A8B7E003935EA /* Bezier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bezier.swift; sourceTree = "<group>"; };
@@ -7493,6 +7496,8 @@
 			children = (
 				4FF6663725F2C93A00689B77 /* ModifiedDrag.h */,
 				4FF6663825F2C93A00689B77 /* ModifiedDrag.m */,
+					DD000001000000000000DD01 /* ModifiedDragOutputRotateZoom.h */,
+					DD000001000000000000DD02 /* ModifiedDragOutputRotateZoom.m */,
 				4FCB260D293147CD0066EE56 /* ModifiedDrag.swift */,
 				4FF0255827B00F9700923107 /* ThreeFingerSwipe */,
 				4FF0255927B00FA400923107 /* TwoFingerSwipe */,
@@ -8174,6 +8179,7 @@
 				4F9C9B58268A29B70083DED0 /* RollingAverage.swift in Sources */,
 				4FFA4E4428B7D28E0062A1FE /* ConstraintUtility.swift in Sources */,
 				4FF0255727B0091700923107 /* ModifiedDragOutputAddMode.m in Sources */,
+					DD000001000000000000DD03 /* ModifiedDragOutputRotateZoom.m in Sources */,
 				4FF0255127B0033000923107 /* ModifiedDragOutputTwoFingerSwipe.m in Sources */,
 				4FC8A7CE28AAF1BC007DB982 /* MarkdownParser.swift in Sources */,
 				4FF6654D25F2C7B000689B77 /* SharedUtility.m in Sources */,

--- a/Shared/Constants.h
+++ b/Shared/Constants.h
@@ -141,6 +141,8 @@ typedef NSString*                                                       MFString
 #define kMFModifiedDragTypeThreeFingerSwipe                             @"threeFingerSwipe"
 #define kMFModifiedDragTypeFakeDrag                                     @"fakeDrag"
 #define kMFModifiedDragTypeAddModeFeedback                              @"addModeDrag"
+#define kMFModifiedDragTypeRotate                                       @"rotate"
+#define kMFModifiedDragTypeZoom                                         @"zoom"
 // Variant keys
 #define kMFModifiedDragDictKeyFakeDragVariantButtonNumber               @"buttonNumber"
 

--- a/Shared/Devices/DeviceManager.m
+++ b/Shared/Devices/DeviceManager.m
@@ -32,6 +32,7 @@
 
 #import "SharedUtility.h"
 #import "Mac_Mouse_Fix_Helper-Swift.h"
+#import "LogitechCIDActivator.h"
 
 @implementation DeviceManager
 
@@ -267,6 +268,9 @@ static void handleDeviceMatching(void *context, IOReturn result, void *sender, I
         
     #endif
         
+        /// Activate Logitech HID++ CID diversion for extra buttons
+        [[LogitechCIDActivator shared] handleDeviceAttached: device];
+
         /// Log
         DDLogInfo(@"New device added to attached devices:\n%@", newDevice);
         
@@ -307,6 +311,9 @@ static void handleDeviceRemoval(void *context, IOReturn result, void *sender, IO
 //        [Scroll decide];
 //        [ButtonInputReceiver decide];
         
+        /// Clean up Logitech CID diversion
+        [[LogitechCIDActivator shared] handleDeviceRemoved: device];
+
         /// Log
         
         DDLogInfo(@"Attached device was removed:\n%@", attachedDevice);


### PR DESCRIPTION
Adds rotate and zoom as drag output plugins — hold a button and move the mouse to rotate or zoom.

- **Rotate**: horizontal mouse movement → rotation (like twisting 2 fingers on trackpad). Works in Apple Maps, Photos, Preview.
- **Zoom**: vertical mouse movement → magnification (like pinching on trackpad). Works in Safari, Maps, any app supporting pinch-to-zoom.

Uses existing TouchSimulator methods with proper phase handling (Began/Changed/Ended/Cancelled).

New files: ModifiedDragOutputRotateZoom.h/.m