### PR TITLE
Fix dock-swipe gestures (Mission Control / Spaces / Show Desktop) on macOS 27

### DIFF
--- a/Shared/IOKit/CGEventHIDEventBridge.m
+++ b/Shared/IOKit/CGEventHIDEventBridge.m
@@ -36,6 +36,10 @@ void CGEventSetHIDEvent(CGEventRef cgEvent, HIDEvent *hidEvent) {
 }
 
 /// Defining our own IOHIDEvent -> CGEvent function, because we can't link against `_SLEventSetIOHIDEvent`. (See header)
+/// Using SLEventSetIOHIDEvent from SkyLight.framework instead of the custom pointer-offset hack,
+/// which broke in macOS 27 due to CGEvent internal layout changes.
+extern void SLEventSetIOHIDEvent(CGEventRef cgEvent, IOHIDEventRef iohidEvent);
+
 void CGEventSetIOHIDEvent(CGEventRef cgEvent, IOHIDEventRef iohidEvent) {
     
     /// Validate
@@ -53,14 +57,7 @@ void CGEventSetIOHIDEvent(CGEventRef cgEvent, IOHIDEventRef iohidEvent) {
     ///     Update: [Apr 2025] ... that means if we're replacing an existing IOHIDEventRef here it might get leaked.
     CFRetain(iohidEvent);
     
-    /// Get ptr
-    void *resultHIDPtr = (void *)cgEvent;
-    applyOffset(&resultHIDPtr, 0x18); /// Shift || Update: [Apr 2025] SLSIsEventMatchingSymbolicHotKey() disassembly might suggest that 0x18 points to a CGSEventRecord
-    resultHIDPtr = *(void **)resultHIDPtr; /// Dereference
-    applyOffset(&resultHIDPtr, 0xd0); /// Shift
-    
-    /// Store IOHIDEvent
-    *(IOHIDEventRef *)resultHIDPtr = iohidEvent; /// Store pointer to iohidEvent
+    SLEventSetIOHIDEvent(cgEvent, iohidEvent);
 }
 
 /// MARK: Helper


### PR DESCRIPTION
> **Disclaimer**
> 
> This PR is AI-assisted (Claude Code) exploration and modification, intended only for **bug reporting and fix reference**.
> 
> I am not a core contributor to this project. If considering merging, please **review thoroughly**.
> 
> ---
> 
> ## Test Environment
> 
> - **Device**: MacBook Pro M3 Max (Apple Silicon)
> - **OS**: macOS 27.0 (Build 26A5368g) -- Tahoe / "Golden Gate" beta
> - **Xcode**: 26.6 (Build 17F113)
> 
> ---
> 
> ## Problem
> 
> On the macOS 27 beta, dock-swipe gestures stop working entirely -- e.g. mapping a button to **Mission Control and Spaces** or **Desktop and Dock** via click-and-drag does nothing.
> 
> ## Root Cause
> 
> macOS 27 changed the internal `CGEvent` structure layout. The existing custom `CGEventSetIOHIDEvent` implementation uses hard-coded pointer offsets (`0x18` / `0xd0`) to embed `IOHIDEvent` payloads into `CGEvent`. These offsets no longer point to the correct location on macOS 27, so the Dock server cannot read gesture data from synthetic events.
> 
> ## Fix
> 
> Replace the custom pointer-offset implementation with `SLEventSetIOHIDEvent` from `SkyLight.framework`. SkyLight is already linked in the project, and the exploration code in `Tests/FixDockSwipes.m` confirmed this function works on macOS 27.
> 
> **Files changed**: `Shared/IOKit/CGEventHIDEventBridge.m` only (+5/-8 lines)