### PR TITLE
Fix Dock Swipe simulation on macOS 27 (Spaces & Mission Control)

### DIFF
--- a/Shared/IOKit/CGEventHIDEventBridge.m
+++ b/Shared/IOKit/CGEventHIDEventBridge.m
@@ -9,6 +9,12 @@
 
 #import "CGEventHIDEventBridge.h"
 @import CoreGraphics.CGEvent;
+#import <dlfcn.h>
+
+/// Forward declarations for helpers defined later in this file
+void CGEventSetIOHIDEvent(CGEventRef cgEvent, IOHIDEventRef iohidEvent);
+void setIOHIDEvent_ManualOffsets(CGEventRef cgEvent, IOHIDEventRef iohidEvent);
+void applyOffset(void **ptr, uint8_t byteOffset);
 
 @implementation CGEventHIDEventBridge
 
@@ -35,7 +41,24 @@ void CGEventSetHIDEvent(CGEventRef cgEvent, HIDEvent *hidEvent) {
     return CGEventSetIOHIDEvent(cgEvent, (__bridge IOHIDEventRef)hidEvent);
 }
 
-/// Defining our own IOHIDEvent -> CGEvent function, because we can't link against `_SLEventSetIOHIDEvent`. (See header)
+/// IOHIDEvent -> CGEvent
+///     We prefer Apple's own private `SLEventSetIOHIDEvent` (SkyLight.framework), resolved at runtime via dlsym.
+///     If it can't be found, we fall back to our hand-rolled pointer-offset implementation.
+///
+///     Why prefer `SLEventSetIOHIDEvent`:
+///         Our hand-rolled implementation (`setIOHIDEvent_ManualOffsets`) depends on the private memory layout of
+///         `CGEvent`/`CGSEventRecord`, which Apple can change between OS versions. On macOS 27 (Golden Gate) Beta 3,
+///         this layout changed: the hardcoded `0x18`/`0xd0` offsets no longer point at the embedded IOHIDEvent slot,
+///         so the IOHIDEvent was written to the wrong address. This broke DockSwipe simulation, meaning the
+///         `Spaces & Mission Control` action (switching Spaces / opening Mission Control via Click & Drag) stopped working.
+///
+///         `SLEventSetIOHIDEvent` doesn't depend on any hardcoded offsets and keeps working across OS versions.
+///         (This is the same function the working exploration in `Tests/FixDockSwipes.m` used.)
+///
+///     Why dlsym instead of linking:
+///         SkyLight.framework is a private framework, but it's already loaded into the process (via AppKit / CoreGraphics),
+///         so we can resolve the symbol at runtime without adding it to the Xcode target. This avoids project-file changes
+///         and gracefully degrades to the old implementation if the symbol ever disappears.
 void CGEventSetIOHIDEvent(CGEventRef cgEvent, IOHIDEventRef iohidEvent) {
     
     /// Validate
@@ -47,6 +70,30 @@ void CGEventSetIOHIDEvent(CGEventRef cgEvent, IOHIDEventRef iohidEvent) {
         assert(false);
         return;
     }
+    
+    /// Resolve `SLEventSetIOHIDEvent` once
+    typedef void (*SLEventSetIOHIDEventFuncType)(CGEventRef, IOHIDEventRef);
+    static SLEventSetIOHIDEventFuncType SLEventSetIOHIDEventFunc = NULL;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        SLEventSetIOHIDEventFunc = (SLEventSetIOHIDEventFuncType)dlsym(RTLD_DEFAULT, "SLEventSetIOHIDEvent");
+    });
+    
+    /// Use Apple's function if available
+    ///     Note: We don't `CFRetain(iohidEvent)` here – unlike our manual implementation, `SLEventSetIOHIDEvent`
+    ///     manages the retain/release of the embedded event itself.
+    if (SLEventSetIOHIDEventFunc != NULL) {
+        SLEventSetIOHIDEventFunc(cgEvent, iohidEvent);
+        return;
+    }
+    
+    /// Fallback: hand-rolled implementation
+    setIOHIDEvent_ManualOffsets(cgEvent, iohidEvent);
+}
+
+/// Hand-rolled IOHIDEvent -> CGEvent implementation, kept as a fallback.
+///     Fragile: depends on the private memory layout of CGEvent/CGSEventRecord (hardcoded offsets), which changes between OS versions.
+void setIOHIDEvent_ManualOffsets(CGEventRef cgEvent, IOHIDEventRef iohidEvent) {
     
     /// Retain
     ///     CFRelease(cgEvent) also releases the embedded IOHIDEventRef


### PR DESCRIPTION
## Problem

On macOS 27 (Golden Gate), the **Spaces & Mission Control** action stopped working when triggered via Click & Drag (switching Spaces, opening Mission Control / App Windows). The simulated dock swipe events were no longer registered by the system.

## Root cause

The macOS 27 code path in `TouchSimulator` attaches an `IOHIDEvent` to a `CGEvent` via `CGEventSetHIDEvent` → `CGEventSetIOHIDEvent`. That function is a hand-rolled reimplementation that writes the `IOHIDEvent` pointer into the `CGEvent` using hardcoded offsets (`0x18` / `0xd0`) into the private `CGEvent`/`CGSEventRecord` layout.

macOS 27 changed that layout, so the pointer was written to the wrong address and the resulting dock swipe carried no valid HID event.

## Fix

Prefer Apple's own private `SLEventSetIOHIDEvent` (SkyLight), resolved at runtime via `dlsym`, and fall back to the offset-based implementation only if the symbol can't be found. This matches the working approach explored in `Tests/FixDockSwipes.m`.

- **Backwards compatible:** `SLEventSetIOHIDEvent` exists on older macOS too, so it's used there as well; the hand-rolled method stays as a graceful fallback. No macOS-version gate needed.
- **Why `dlsym` instead of linking SkyLight.framework:** linking a private framework at build time could be an issue for the Mac App Store variant, whereas `dlsym` creates no link-time dependency and degrades gracefully if the symbol ever disappears.

## Testing

- Built and tested on **macOS 27 Golden Gate Beta 3** (Xcode 27 beta 3), Apple Silicon (M2).
- Middle-button **Click & Drag → Spaces & Mission Control** works again: switching Spaces (left/right), Mission Control (up), and App Windows (down).
- Single file changed: `Shared/IOKit/CGEventHIDEventBridge.m`.
