### PR TITLE
Fix dock-swipe gestures on macOS 27

### DIFF
--- a/Helper/Core/Drag/ThreeFingerSwipe/ModifiedDragOutputThreeFingerSwipe.m
+++ b/Helper/Core/Drag/ThreeFingerSwipe/ModifiedDragOutputThreeFingerSwipe.m
@@ -21,6 +21,80 @@
 static ModifiedDragState *_drag;
 
 static int16_t _nOfSpaces = 1;
+static BOOL _didFreezePointer = NO;
+static BOOL _dockSwipeBegan = NO;
+static BOOL _dockSwipeSuppressedUntilRelease = NO;
+static CGRect _dragOriginScreenBounds;
+
+static BOOL shouldUseAnchoredDockSwipeEvents(void) {
+
+    return [NSProcessInfo.processInfo isOperatingSystemAtLeastVersion:(NSOperatingSystemVersion){27, 0, 0}];
+}
+
+static CGRect screenBoundsContainingPoint(CGPoint point) {
+
+    uint32_t displayCount = 0;
+    CGDirectDisplayID displays[16];
+    if (CGGetActiveDisplayList(16, displays, &displayCount) == kCGErrorSuccess) {
+        for (uint32_t i = 0; i < displayCount; i++) {
+            CGRect bounds = CGDisplayBounds(displays[i]);
+            if (CGRectContainsPoint(bounds, point)) {
+                return bounds;
+            }
+        }
+    }
+
+    return CGDisplayBounds(CGMainDisplayID());
+}
+
+static CGSize screenSizeForDragOrigin(void) {
+
+    return screenBoundsContainingPoint(_drag->usageOrigin).size;
+}
+
+static CGPoint eventLocation(CGEventRef event) {
+
+    if (event != NULL) {
+        return CGEventGetLocation(event);
+    }
+
+    CGEventRef currentEvent = CGEventCreate(NULL);
+    CGPoint location = currentEvent ? CGEventGetLocation(currentEvent) : _drag->usageOrigin;
+    if (currentEvent) CFRelease(currentEvent);
+    return location;
+}
+
+static MFDockSwipeType currentDockSwipeType(void) {
+
+    if (_drag->usageAxis == kMFAxisHorizontal) {
+        return kMFDockSwipeTypeHorizontal;
+    } else if (_drag->usageAxis == kMFAxisVertical) {
+        return kMFDockSwipeTypeVertical;
+    } else {
+        assert(false);
+        return kMFDockSwipeTypeHorizontal;
+    }
+}
+
+static void endDockSwipeAtDragOrigin(void) {
+
+    if (!_dockSwipeBegan) return;
+
+    [TouchSimulator postDockSwipeEventWithDelta:0.0 type:currentDockSwipeType() phase:kIOHIDEventPhaseEnded invertedFromDevice:_drag->naturalDirection atPosition:_drag->usageOrigin];
+    _dockSwipeBegan = NO;
+}
+
+static BOOL endDockSwipeIfPointerLeftOriginScreen(CGEventRef event) {
+
+    if (!shouldUseAnchoredDockSwipeEvents()) return NO;
+
+    CGPoint currentLocation = eventLocation(event);
+    if (!_dockSwipeSuppressedUntilRelease && CGRectContainsPoint(_dragOriginScreenBounds, currentLocation)) return NO;
+
+    endDockSwipeAtDragOrigin();
+    _dockSwipeSuppressedUntilRelease = YES;
+    return YES;
+}
 
 /// Interface funcs
 
@@ -29,6 +103,12 @@ static int16_t _nOfSpaces = 1;
 }
 
 + (void)handleBecameInUse {
+
+    _didFreezePointer = NO;
+    _dockSwipeBegan = NO;
+    _dockSwipeSuppressedUntilRelease = NO;
+    _dragOriginScreenBounds = screenBoundsContainingPoint(_drag->usageOrigin);
+
     /// Get number of spaces
     ///     for use in `handleMouseInputWhileInUse()`. Getting it here for performance reasons. Not sure if significant.
     CFArrayRef spaces = CGSCopySpaces(CGSMainConnectionID(), CGSSpaceIncludesUser | CGSSpaceIncludesOthers | CGSSpaceIncludesCurrent);
@@ -38,9 +118,11 @@ static int16_t _nOfSpaces = 1;
     
     CFRelease(spaces);
     
-    /// Freeze pointer
-    if (GeneralConfig.freezePointerDuringModifiedDrag) {
+    /// Freeze pointer only when the user configured it. The macOS 27 Dock-swipe path keeps the real pointer free and
+    /// anchors only the synthetic event position; if the real pointer crosses displays, we end this gesture stream.
+    if (GeneralConfig.freezePointerDuringModifiedDrag && !shouldUseAnchoredDockSwipeEvents()) {
         [PointerFreeze freezePointerAtPosition:_drag->usageOrigin];
+        _didFreezePointer = YES;
     }
 }
 
@@ -52,7 +134,7 @@ static int16_t _nOfSpaces = 1;
      I arrived at these value through testing documented in the NotePlan note "MMF - Scraps - Testing DockSwipe scaling"
      TODO: Test this on a vertical screen
      */
-    CGSize screenSize = NSScreen.mainScreen.frame.size;
+    CGSize screenSize = screenSizeForDragOrigin();
     double originOffsetForOneSpace = _nOfSpaces == 1 ? 2.0 : 1.0 + (1.0 / (_nOfSpaces-1));
     double spaceSeparatorWidth = 63;
     double threeFingerScaleH = originOffsetForOneSpace / (screenSize.width + spaceSeparatorWidth);
@@ -60,42 +142,43 @@ static int16_t _nOfSpaces = 1;
     /// Vertical dockSwipe scaling
     ///     Not sure if it makes sense to scale this with screen height
     double threeFingerScaleV = 1.0 / screenSize.height;
+
+    if (endDockSwipeIfPointerLeftOriginScreen(event)) return;
     
     /// Get phase
     
-    IOHIDEventPhaseBits eventPhase = _drag->firstCallback ? kIOHIDEventPhaseBegan : kIOHIDEventPhaseChanged;
+    IOHIDEventPhaseBits eventPhase = _dockSwipeBegan ? kIOHIDEventPhaseChanged : kIOHIDEventPhaseBegan;
     
     /// Send events
     
     if (_drag->usageAxis == kMFAxisHorizontal) {
         double delta = -deltaX * threeFingerScaleH;
-        [TouchSimulator postDockSwipeEventWithDelta:delta type:kMFDockSwipeTypeHorizontal phase:eventPhase invertedFromDevice:_drag->naturalDirection];
+        [TouchSimulator postDockSwipeEventWithDelta:delta type:kMFDockSwipeTypeHorizontal phase:eventPhase invertedFromDevice:_drag->naturalDirection atPosition:_drag->usageOrigin];
+        _dockSwipeBegan = YES;
     } else if (_drag->usageAxis == kMFAxisVertical) {
         double delta = deltaY * threeFingerScaleV;
-        [TouchSimulator postDockSwipeEventWithDelta:delta type:kMFDockSwipeTypeVertical phase:eventPhase invertedFromDevice:_drag->naturalDirection];
+        [TouchSimulator postDockSwipeEventWithDelta:delta type:kMFDockSwipeTypeVertical phase:eventPhase invertedFromDevice:_drag->naturalDirection atPosition:_drag->usageOrigin];
+        _dockSwipeBegan = YES;
     }
 }
 
 + (void)handleDeactivationWhileInUseWithCancel:(BOOL)cancel {
     
-    MFDockSwipeType type;
+    MFDockSwipeType type = currentDockSwipeType();
     IOHIDEventPhaseBits phase;
-    
-    if (_drag->usageAxis == kMFAxisHorizontal) {
-        type = kMFDockSwipeTypeHorizontal;
-    } else if (_drag->usageAxis == kMFAxisVertical) {
-        type = kMFDockSwipeTypeVertical;
-    } else {
-        assert(false);
-    }
     
     phase = cancel ? kIOHIDEventPhaseCancelled : kIOHIDEventPhaseEnded;
     
-    [TouchSimulator postDockSwipeEventWithDelta:0.0 type:type phase:phase invertedFromDevice:_drag->naturalDirection];
+    if (_dockSwipeBegan) {
+        [TouchSimulator postDockSwipeEventWithDelta:0.0 type:type phase:phase invertedFromDevice:_drag->naturalDirection atPosition:_drag->usageOrigin];
+        _dockSwipeBegan = NO;
+    }
+    _dockSwipeSuppressedUntilRelease = NO;
     
     /// Unfreeze pointer
-    if (GeneralConfig.freezePointerDuringModifiedDrag) {
+    if (_didFreezePointer) {
         [PointerFreeze unfreeze];
+        _didFreezePointer = NO;
     }
     
 }

--- a/Helper/Core/Touch/TouchSimulator.h
+++ b/Helper/Core/Touch/TouchSimulator.h
@@ -8,6 +8,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import <CoreGraphics/CoreGraphics.h>
 #import "MFHIDEventImports.h"
 
 NS_ASSUME_NONNULL_BEGIN
@@ -26,6 +27,7 @@ typedef enum {
 + (void)postRotationEventWithRotation:(double)rotation phase:(IOHIDEventPhaseBits)phase;
 + (void)postMagnificationEventWithMagnification:(double)magnification phase:(IOHIDEventPhaseBits)phase;
 + (void)postDockSwipeEventWithDelta:(double)d type:(MFDockSwipeType)type phase:(IOHIDEventPhaseBits)phase invertedFromDevice:(BOOL)invertedFromDevice;
++ (void)postDockSwipeEventWithDelta:(double)d type:(MFDockSwipeType)type phase:(IOHIDEventPhaseBits)phase invertedFromDevice:(BOOL)invertedFromDevice atPosition:(CGPoint)eventPosition;
 
 
 @end

--- a/Helper/Core/Touch/TouchSimulator.m
+++ b/Helper/Core/Touch/TouchSimulator.m
@@ -271,11 +271,11 @@ static uint8_t *MFGenerateIOHIDPayload(CGEventRef event, size_t *out_length) {
     /// Read the public gesture fields we already set on `e30` in `postDockSwipeEventWithDelta:`.
     int64_t phase     = CGEventGetIntegerValueField(event, (CGEventField)132);
     int64_t motion    = CGEventGetIntegerValueField(event, (CGEventField)123); /// MFDockSwipeType (horizontal/vertical/pinch)
-    double  progress  = -CGEventGetDoubleValueField(event, (CGEventField)124); /// origin offset, inverted for macOS 27 HID payload semantics
+    double  progress  = CGEventGetDoubleValueField (event, (CGEventField)124); /// origin offset
     double  pos_x     = CGEventGetDoubleValueField (event, (CGEventField)125);
     double  pos_y     = CGEventGetDoubleValueField (event, (CGEventField)126);
-    double  vel_x     = -CGEventGetDoubleValueField(event, (CGEventField)129); /// exit speed, inverted to match progress
-    double  vel_y     = -CGEventGetDoubleValueField(event, (CGEventField)130);
+    double  vel_x     = CGEventGetDoubleValueField (event, (CGEventField)129); /// exit speed
+    double  vel_y     = CGEventGetDoubleValueField (event, (CGEventField)130);
     int64_t swipe_mask = CGEventGetIntegerValueField(event, (CGEventField)115);
 
     bool include_velocity = (vel_x != 0.0 || vel_y != 0.0 || phase == kIOHIDEventPhaseEnded);
@@ -613,7 +613,22 @@ static NSMutableDictionary *_swipeInfo;
 
     CGEventRef e30ToPost = e30; /// Borrowed reference unless we replace it with an owned augmented copy below.
     if (MFDockSwipeEventAugmentationRequired()) {
-        CGEventRef augmented = MFCreateAugmentedDockSwipeEvent(e30);
+        CGEventRef e30ForAugmentation = CGEventCreateCopy(e30);
+        if (e30ForAugmentation) {
+            /// macOS 27's Dock consumes the raw HID payload, and its sign convention is inverted relative to the
+            /// public CGEvent fields MMF used historically. Keep this isolated to the augmented event path.
+            double progress = -CGEventGetDoubleValueField(e30ForAugmentation, (CGEventField)124);
+            CGEventSetDoubleValueField(e30ForAugmentation, 124, progress);
+            Float32 progressFloat32 = (Float32)progress;
+            uint32_t progressInt32;
+            memcpy(&progressInt32, &progressFloat32, sizeof(progressFloat32));
+            CGEventSetIntegerValueField(e30ForAugmentation, 135, (int64_t)progressInt32);
+            CGEventSetDoubleValueField(e30ForAugmentation, 129, -CGEventGetDoubleValueField(e30ForAugmentation, (CGEventField)129));
+            CGEventSetDoubleValueField(e30ForAugmentation, 130, -CGEventGetDoubleValueField(e30ForAugmentation, (CGEventField)130));
+        }
+        CGEventRef eventForAugmentation = e30ForAugmentation ? e30ForAugmentation : e30;
+        CGEventRef augmented = MFCreateAugmentedDockSwipeEvent(eventForAugmentation);
+        if (e30ForAugmentation) CFRelease(e30ForAugmentation);
         if (augmented != NULL) {
             e30ToPost = augmented; /// Owned (+1); released at the end of this function.
         } else {

--- a/Helper/Core/Touch/TouchSimulator.m
+++ b/Helper/Core/Touch/TouchSimulator.m
@@ -37,6 +37,7 @@
 ///         - https://github.com/noah-nuebling/mac-mouse-fix/issues/1892
 ///     The fix (first worked out by the InstantSpaceSwitcher / FasterSwiper community) is to embed the *raw IOKit HID
 ///     event payload* into the serialized CGEvent (field 4205) so the Dock server has the data it now requires. See:
+///         - https://github.com/noah-nuebling/mac-mouse-fix/pull/1895
 ///         - https://github.com/jurplel/InstantSpaceSwitcher/issues/72
 ///         - https://gist.github.com/mgbowen/5548f18ada2e37b23c9e86a8d80b71dc  (serialization-format notes)
 ///
@@ -455,6 +456,15 @@ static NSMutableDictionary *_swipeInfo;
 
 + (void)postDockSwipeEventWithDelta:(double)d type:(MFDockSwipeType)type phase:(IOHIDEventPhaseBits)phase invertedFromDevice:(BOOL)invertedFromDevice {
 
+    CGEventRef event = CGEventCreate(NULL);
+    CGPoint eventPosition = event ? CGEventGetLocation(event) : CGPointZero;
+    if (event) CFRelease(event);
+
+    [self postDockSwipeEventWithDelta:d type:type phase:phase invertedFromDevice:invertedFromDevice atPosition:eventPosition];
+}
+
++ (void)postDockSwipeEventWithDelta:(double)d type:(MFDockSwipeType)type phase:(IOHIDEventPhaseBits)phase invertedFromDevice:(BOOL)invertedFromDevice atPosition:(CGPoint)eventPosition {
+
     /// Fix Apple bug
     ///   If we don't do this, the exitSpeed is interpreted in the wrong direction when opening Launchpad, leading to a noticable jitter.
     ///   This also happens on an Apple Trackpad if you turn natural scrolling off.
@@ -576,6 +586,8 @@ static NSMutableDictionary *_swipeInfo;
     
     CGEventSetDoubleValueField(e30, 123, type); /// Horizontal or vertical
     CGEventSetDoubleValueField(e30, 165, type); /// Horizontal or vertical // Probs not necessary
+    CGEventSetDoubleValueField(e30, 125, eventPosition.x);
+    CGEventSetDoubleValueField(e30, 126, eventPosition.y);
     
     CGEventSetIntegerValueField(e30, 136, invertedFromDevice ? 1 : 0);
     
@@ -662,10 +674,12 @@ static NSMutableDictionary *_swipeInfo;
             _tripleSendTimer = nil;
         });
         
-    } else if (phase == kIOHIDEventPhaseEnded || phase == kIOHIDEventPhaseCancelled) {
+    } else if ((phase == kIOHIDEventPhaseEnded || phase == kIOHIDEventPhaseCancelled) && !MFDockSwipeEventAugmentationRequired()) {
 
         /// Double-send end-events
         /// Notes:
+        ///     - macOS 27 uses the embedded raw HID payload. The augmented path skips these delayed replays so stale
+        ///       end events cannot poison Dock's multi-display gesture state after a new swipe has started.
         ///     - The inital dockSwipe event we post will be ignored by the system when it is under load (I called this the "stuck bug" in other places). Sending the event again with a delay of 200ms (0.2s) gets it unstuck almost always. Sending the event twice gives us the best of both responsiveness and reliability.
         ///     - In Scroll.m, even with sending the event again after 0.2 seconds, the stuck bug still happens a bunch for some reason. Even though this almost completely eliminates the bug in ModifiedDrag.m . Sending it again after 0.5 seconds works better but still sometimes happens.
         ///         Edit: Doesn't happen anymore on M1. Edit 2: [Feb 2025] The double-sending code used to be broken for a while (fixed in e8f90d2f32829e3e5f1621fa8e4b58634c9ea07b) . Maybe that's why we observed the stuck-bug for Scroll.m here?

--- a/Helper/Core/Touch/TouchSimulator.m
+++ b/Helper/Core/Touch/TouchSimulator.m
@@ -271,11 +271,11 @@ static uint8_t *MFGenerateIOHIDPayload(CGEventRef event, size_t *out_length) {
     /// Read the public gesture fields we already set on `e30` in `postDockSwipeEventWithDelta:`.
     int64_t phase     = CGEventGetIntegerValueField(event, (CGEventField)132);
     int64_t motion    = CGEventGetIntegerValueField(event, (CGEventField)123); /// MFDockSwipeType (horizontal/vertical/pinch)
-    double  progress  = CGEventGetDoubleValueField (event, (CGEventField)124); /// origin offset
+    double  progress  = -CGEventGetDoubleValueField(event, (CGEventField)124); /// origin offset, inverted for macOS 27 HID payload semantics
     double  pos_x     = CGEventGetDoubleValueField (event, (CGEventField)125);
     double  pos_y     = CGEventGetDoubleValueField (event, (CGEventField)126);
-    double  vel_x     = CGEventGetDoubleValueField (event, (CGEventField)129); /// exit speed
-    double  vel_y     = CGEventGetDoubleValueField (event, (CGEventField)130);
+    double  vel_x     = -CGEventGetDoubleValueField(event, (CGEventField)129); /// exit speed, inverted to match progress
+    double  vel_y     = -CGEventGetDoubleValueField(event, (CGEventField)130);
     int64_t swipe_mask = CGEventGetIntegerValueField(event, (CGEventField)115);
 
     bool include_velocity = (vel_x != 0.0 || vel_y != 0.0 || phase == kIOHIDEventPhaseEnded);
@@ -717,4 +717,3 @@ static NSMutableDictionary *_swipeInfo;
 
 
 @end
-

--- a/Helper/Core/Touch/TouchSimulator.m
+++ b/Helper/Core/Touch/TouchSimulator.m
@@ -26,6 +26,367 @@
 #import <Foundation/Foundation.h>
 #import "HelperUtility.h"
 
+#import <mach/mach_time.h>
+
+#pragma mark - macOS 27 dock-swipe augmentation
+
+/// Background:
+///     Starting with macOS 27 (Tahoe/"Golden Gate" beta), the Dock server no longer acts on the *public* CGEvent gesture
+///     fields for synthetic dock-swipe events. As a result the Mission Control / Spaces / Show-Desktop gestures that
+///     `postDockSwipeEventWithDelta:` produces simply do nothing on the beta. See:
+///         - https://github.com/noah-nuebling/mac-mouse-fix/issues/1892
+///     The fix (first worked out by the InstantSpaceSwitcher / FasterSwiper community) is to embed the *raw IOKit HID
+///     event payload* into the serialized CGEvent (field 4205) so the Dock server has the data it now requires. See:
+///         - https://github.com/jurplel/InstantSpaceSwitcher/issues/72
+///         - https://gist.github.com/mgbowen/5548f18ada2e37b23c9e86a8d80b71dc  (serialization-format notes)
+///
+/// How it works:
+///     `CGEventCreateData()` / `CGEventCreateFromData()` use a private big-endian serialization format. We serialize the
+///     event we already built, parse out its fields, splice in (or replace) field 4205 with a hand-built IOHID payload,
+///     re-serialize, and rebuild the event with `CGEventCreateFromData()`. The numeric values inside the payload are
+///     16.16 fixed-point, so precision is limited (a known consequence of this approach).
+///
+/// Caveats (this is reverse-engineered and could not be verified on-device against the beta here):
+///     - The Dock server's sign convention for `progress`/`velocity` may be inverted on macOS 27 relative to older
+///       versions. If a gesture triggers the *opposite* direction on the beta, flip the sign of field 124 (and/or the
+///       velocity fields 129/130) in `postDockSwipeEventWithDelta:` for the augmented path.
+///     - `gesture_flavor` is hard-coded to the "dock primary" flavor, which is what the space-switching apps use. If
+///       vertical (Mission Control) or pinch (Show Desktop/Launchpad) gestures misbehave, this is the first knob to try.
+
+static const uint8_t kMFCGEventDataTagInt64OrBlob   = 0b00;
+static const uint8_t kMFCGEventDataTagInt32         = 0b01;
+static const uint8_t kMFCGEventDataTagFloatingPoint = 0b11;
+
+static const uint16_t kMFCGEventFieldGestureRawDataPayload = 4205;
+
+typedef struct {
+    uint16_t field_id;
+    uint8_t tag;
+    uint16_t size_words;
+    uint8_t *payload;
+    size_t payload_length;
+} MFCGEventParsedField;
+
+typedef struct {
+    int32_t version;
+    MFCGEventParsedField *fields;
+    size_t field_count;
+    size_t field_capacity;
+} MFCGEventParsedData;
+
+static uint16_t MFReadBE16(const uint8_t *data, size_t offset) {
+    return (uint16_t)((data[offset] << 8) | data[offset + 1]);
+}
+static uint32_t MFReadBE32(const uint8_t *data, size_t offset) {
+    return ((uint32_t)data[offset] << 24) | ((uint32_t)data[offset + 1] << 16) |
+           ((uint32_t)data[offset + 2] << 8) | (uint32_t)data[offset + 3];
+}
+static void MFWriteBE16(uint8_t *out, size_t offset, uint16_t value) {
+    out[offset]     = (uint8_t)((value >> 8) & 0xFF);
+    out[offset + 1] = (uint8_t)(value & 0xFF);
+}
+static void MFWriteBE32(uint8_t *out, size_t offset, uint32_t value) {
+    out[offset]     = (uint8_t)((value >> 24) & 0xFF);
+    out[offset + 1] = (uint8_t)((value >> 16) & 0xFF);
+    out[offset + 2] = (uint8_t)((value >> 8) & 0xFF);
+    out[offset + 3] = (uint8_t)(value & 0xFF);
+}
+
+static void MFParsedEventDataFree(MFCGEventParsedData *parsed) {
+    if (!parsed || !parsed->fields) return;
+    for (size_t i = 0; i < parsed->field_count; i++) {
+        free(parsed->fields[i].payload);
+    }
+    free(parsed->fields);
+    parsed->fields = NULL;
+    parsed->field_count = 0;
+    parsed->field_capacity = 0;
+}
+
+static bool MFParseEventData(const uint8_t *data, size_t length, MFCGEventParsedData *out) {
+    memset(out, 0, sizeof(*out));
+    if (length < 4) return false;
+
+    out->version = (int32_t)MFReadBE32(data, 0);
+    if (out->version != 2) {
+        DDLogWarn(@"TouchSimulator: Unsupported CGEvent data version %d during dock-swipe augmentation", out->version);
+        return false;
+    }
+
+    out->field_capacity = 16;
+    out->fields = (MFCGEventParsedField *)calloc(out->field_capacity, sizeof(MFCGEventParsedField));
+    if (!out->fields) return false;
+
+    size_t offset = 4;
+    while (offset < length) {
+        if (offset + 4 > length) { MFParsedEventDataFree(out); return false; }
+
+        uint16_t size_words = MFReadBE16(data, offset);
+        uint16_t tag_and_field = MFReadBE16(data, offset + 2);
+        uint8_t tag = (uint8_t)((tag_and_field >> 14) & 0x3);
+        uint16_t field_id = (uint16_t)(tag_and_field & 0x3FFF);
+        offset += 4;
+
+        size_t payload_length = 0;
+        switch (tag) {
+            case kMFCGEventDataTagInt64OrBlob:
+                if (size_words == 1)      payload_length = 8;
+                else if (size_words > 1)  payload_length = size_words;
+                else { MFParsedEventDataFree(out); return false; }
+                break;
+            case kMFCGEventDataTagInt32:
+            case kMFCGEventDataTagFloatingPoint:
+                payload_length = (size_t)size_words * 4;
+                break;
+            default:
+                MFParsedEventDataFree(out); return false;
+        }
+
+        if (offset + payload_length > length) { MFParsedEventDataFree(out); return false; }
+
+        if (out->field_count >= out->field_capacity) {
+            size_t new_capacity = out->field_capacity * 2;
+            MFCGEventParsedField *new_fields = (MFCGEventParsedField *)realloc(out->fields, new_capacity * sizeof(MFCGEventParsedField));
+            if (!new_fields) { MFParsedEventDataFree(out); return false; }
+            out->fields = new_fields;
+            out->field_capacity = new_capacity;
+        }
+
+        MFCGEventParsedField *field = &out->fields[out->field_count++];
+        field->field_id = field_id;
+        field->tag = tag;
+        field->size_words = size_words;
+        field->payload_length = payload_length;
+        if (payload_length > 0) {
+            field->payload = (uint8_t *)malloc(payload_length);
+            if (!field->payload) { MFParsedEventDataFree(out); return false; }
+            memcpy(field->payload, data + offset, payload_length);
+        } else {
+            field->payload = NULL;
+        }
+        offset += payload_length;
+    }
+    return true;
+}
+
+static size_t MFComputeSerializedLength(const MFCGEventParsedData *parsed, size_t new_payload_length) {
+    size_t len = 4; /// version
+    bool has4205 = false;
+    for (size_t i = 0; i < parsed->field_count; i++) {
+        if (parsed->fields[i].field_id == kMFCGEventFieldGestureRawDataPayload) {
+            len += 4 + new_payload_length;
+            has4205 = true;
+        } else {
+            len += 4 + parsed->fields[i].payload_length;
+        }
+    }
+    if (!has4205) len += 4 + new_payload_length;
+    return len;
+}
+
+static uint8_t *MFSerializeEventData(const MFCGEventParsedData *parsed, const uint8_t *new_payload, size_t new_payload_length, size_t *out_length) {
+    size_t total_length = MFComputeSerializedLength(parsed, new_payload_length);
+    uint8_t *result = (uint8_t *)malloc(total_length);
+    if (!result) return NULL;
+
+    size_t offset = 0;
+    MFWriteBE32(result, offset, (uint32_t)parsed->version);
+    offset += 4;
+
+    bool added4205 = false;
+    for (size_t i = 0; i < parsed->field_count; i++) {
+        const MFCGEventParsedField *field = &parsed->fields[i];
+        if (field->field_id == kMFCGEventFieldGestureRawDataPayload) {
+            MFWriteBE16(result, offset, (uint16_t)new_payload_length); offset += 2;
+            MFWriteBE16(result, offset, (uint16_t)((kMFCGEventDataTagInt64OrBlob << 14) | kMFCGEventFieldGestureRawDataPayload)); offset += 2;
+            memcpy(result + offset, new_payload, new_payload_length); offset += new_payload_length;
+            added4205 = true;
+        } else {
+            MFWriteBE16(result, offset, field->size_words); offset += 2;
+            MFWriteBE16(result, offset, (uint16_t)((field->tag << 14) | field->field_id)); offset += 2;
+            memcpy(result + offset, field->payload, field->payload_length); offset += field->payload_length;
+        }
+    }
+
+    if (!added4205) {
+        MFWriteBE16(result, offset, (uint16_t)new_payload_length); offset += 2;
+        MFWriteBE16(result, offset, (uint16_t)((kMFCGEventDataTagInt64OrBlob << 14) | kMFCGEventFieldGestureRawDataPayload)); offset += 2;
+        memcpy(result + offset, new_payload, new_payload_length); offset += new_payload_length;
+    }
+
+    *out_length = offset;
+    return result;
+}
+
+#pragma pack(push, 1)
+typedef struct {
+    uint32_t size;
+    uint32_t type;
+    uint32_t options;
+    uint8_t depth;
+    uint8_t reserved[3];
+} MFIOHIDEventBase;
+
+typedef struct {
+    MFIOHIDEventBase base;
+    int32_t position_x;
+    int32_t position_y;
+    int32_t position_z;
+    uint32_t swipe_mask;
+    uint16_t gesture_motion;
+    uint16_t gesture_flavor;
+    int32_t swipe_progress;
+} MFIOHIDFluidTouchGestureData;
+
+typedef struct {
+    MFIOHIDEventBase base;
+    int32_t velocity_x;
+    int32_t velocity_y;
+    int32_t velocity_z;
+} MFIOHIDVelocityEventData;
+
+typedef struct {
+    uint64_t timestamp;
+    uint64_t sender_id;
+    uint32_t options;
+    uint32_t attribute_length;
+    uint32_t event_count;
+} MFIOHIDSystemQueueElementHeader;
+#pragma pack(pop)
+
+static const uint32_t kMFIOHIDEventTypeVelocity          = 9;
+static const uint32_t kMFIOHIDEventTypeFluidTouchGesture = 23;
+static const uint16_t kMFIOHIDGestureFlavorDockPrimary   = 3;
+
+static int32_t MFDoubleToFixed1616(double val) {
+    int32_t fixed = (int32_t)(val * 65536.0);
+    if (fixed == 0 && val != 0.0) {
+        return val > 0.0 ? 1 : -1;
+    }
+    return fixed;
+}
+
+static uint8_t *MFGenerateIOHIDPayload(CGEventRef event, size_t *out_length) {
+
+    /// Read the public gesture fields we already set on `e30` in `postDockSwipeEventWithDelta:`.
+    int64_t phase     = CGEventGetIntegerValueField(event, (CGEventField)132);
+    int64_t motion    = CGEventGetIntegerValueField(event, (CGEventField)123); /// MFDockSwipeType (horizontal/vertical/pinch)
+    double  progress  = CGEventGetDoubleValueField (event, (CGEventField)124); /// origin offset
+    double  pos_x     = CGEventGetDoubleValueField (event, (CGEventField)125);
+    double  pos_y     = CGEventGetDoubleValueField (event, (CGEventField)126);
+    double  vel_x     = CGEventGetDoubleValueField (event, (CGEventField)129); /// exit speed
+    double  vel_y     = CGEventGetDoubleValueField (event, (CGEventField)130);
+    int64_t swipe_mask = CGEventGetIntegerValueField(event, (CGEventField)115);
+
+    bool include_velocity = (vel_x != 0.0 || vel_y != 0.0 || phase == kIOHIDEventPhaseEnded);
+    uint32_t event_count = include_velocity ? 2 : 1;
+    size_t payload_length = sizeof(MFIOHIDSystemQueueElementHeader) + sizeof(MFIOHIDFluidTouchGestureData);
+    if (include_velocity) payload_length += sizeof(MFIOHIDVelocityEventData);
+
+    uint8_t *payload = (uint8_t *)malloc(payload_length);
+    if (!payload) return NULL;
+    memset(payload, 0, payload_length);
+
+    size_t offset = 0;
+
+    MFIOHIDSystemQueueElementHeader *header = (MFIOHIDSystemQueueElementHeader *)(payload + offset);
+    offset += sizeof(MFIOHIDSystemQueueElementHeader);
+    uint64_t timestamp = CGEventGetTimestamp(event);
+    if (timestamp == 0) timestamp = mach_absolute_time();
+    header->timestamp = timestamp;
+    header->sender_id = 0;
+    header->options = 0;
+    header->attribute_length = 0;
+    header->event_count = event_count;
+
+    MFIOHIDFluidTouchGestureData *fluid = (MFIOHIDFluidTouchGestureData *)(payload + offset);
+    offset += sizeof(MFIOHIDFluidTouchGestureData);
+    fluid->base.size = sizeof(MFIOHIDFluidTouchGestureData);
+    fluid->base.type = kMFIOHIDEventTypeFluidTouchGesture;
+    fluid->base.options = (uint32_t)((phase & 0xFF) << 24);
+    fluid->base.depth = 0;
+    fluid->position_x = MFDoubleToFixed1616(pos_x);
+    fluid->position_y = MFDoubleToFixed1616(pos_y);
+    fluid->position_z = 0;
+    fluid->swipe_mask = (uint32_t)swipe_mask;
+    fluid->gesture_motion = (uint16_t)motion;
+    fluid->gesture_flavor = kMFIOHIDGestureFlavorDockPrimary;
+    fluid->swipe_progress = MFDoubleToFixed1616(progress);
+
+    if (include_velocity) {
+        MFIOHIDVelocityEventData *velocity = (MFIOHIDVelocityEventData *)(payload + offset);
+        velocity->base.size = sizeof(MFIOHIDVelocityEventData);
+        velocity->base.type = kMFIOHIDEventTypeVelocity;
+        velocity->base.options = 0;
+        velocity->base.depth = 1;
+        velocity->velocity_x = MFDoubleToFixed1616(vel_x);
+        velocity->velocity_y = MFDoubleToFixed1616(vel_y);
+        velocity->velocity_z = 0;
+    }
+
+    *out_length = payload_length;
+    return payload;
+}
+
+/// Returns a retained, augmented copy of `event` (caller must CFRelease), or NULL on failure.
+static CGEventRef MFCreateAugmentedDockSwipeEvent(CGEventRef event) {
+    if (!event) return NULL;
+
+    CFDataRef data = CGEventCreateData(kCFAllocatorDefault, event);
+    if (!data) {
+        DDLogWarn(@"TouchSimulator: CGEventCreateData failed during dock-swipe augmentation");
+        return NULL;
+    }
+
+    const uint8_t *bytes = CFDataGetBytePtr(data);
+    CFIndex length = CFDataGetLength(data);
+
+    MFCGEventParsedData parsed = {0};
+    if (!MFParseEventData(bytes, (size_t)length, &parsed)) {
+        CFRelease(data);
+        return NULL;
+    }
+
+    size_t payload_length = 0;
+    uint8_t *payload = MFGenerateIOHIDPayload(event, &payload_length);
+    if (!payload) {
+        MFParsedEventDataFree(&parsed);
+        CFRelease(data);
+        return NULL;
+    }
+
+    size_t new_length = 0;
+    uint8_t *new_bytes = MFSerializeEventData(&parsed, payload, payload_length, &new_length);
+    MFParsedEventDataFree(&parsed);
+    free(payload);
+    CFRelease(data);
+    if (!new_bytes) {
+        DDLogWarn(@"TouchSimulator: Failed to serialize augmented dock-swipe CGEvent");
+        return NULL;
+    }
+
+    CFDataRef new_data = CFDataCreate(kCFAllocatorDefault, new_bytes, (CFIndex)new_length);
+    free(new_bytes);
+    if (!new_data) return NULL;
+
+    CGEventRef result = CGEventCreateFromData(kCFAllocatorDefault, new_data);
+    CFRelease(new_data);
+    if (!result) {
+        DDLogWarn(@"TouchSimulator: CGEventCreateFromData failed during dock-swipe augmentation");
+    }
+    return result;
+}
+
+/// Whether the running OS needs the IOHID-payload augmentation (macOS 27+).
+static BOOL MFDockSwipeEventAugmentationRequired(void) {
+    static BOOL required = NO;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        required = [NSProcessInfo.processInfo isOperatingSystemAtLeastVersion:(NSOperatingSystemVersion){27, 0, 0}];
+    });
+    return required;
+}
+
 @implementation TouchSimulator
 
 static NSArray *_nullArray;
@@ -243,12 +604,30 @@ static NSMutableDictionary *_swipeInfo;
     }
     
     ///
+    /// Augment for macOS 27+
+    ///   On macOS 27 the Dock server ignores the public CGEvent gesture fields for synthetic dock swipes; it requires the
+    ///   raw IOHID payload embedded in the serialized event. We post the augmented copy of `e30` instead of `e30` itself.
+    ///   `e29` (the generic NSEventTypeGesture event) doesn't carry the dock-swipe data, so it's posted unchanged.
+    ///   See the big comment block near the top of this file for background & caveats.
+    ///
+
+    CGEventRef e30ToPost = e30; /// Borrowed reference unless we replace it with an owned augmented copy below.
+    if (MFDockSwipeEventAugmentationRequired()) {
+        CGEventRef augmented = MFCreateAugmentedDockSwipeEvent(e30);
+        if (augmented != NULL) {
+            e30ToPost = augmented; /// Owned (+1); released at the end of this function.
+        } else {
+            DDLogWarn(@"TouchSimulator: Dock-swipe augmentation failed; posting un-augmented event (will likely be ignored on macOS 27+)");
+        }
+    }
+
+    ///
     /// Send events
     ///
-    
-    DDLogDebug(@"TouchSimulator: Sending dockSwipe with phase %d with events: %@ %@", phase, e30, e29);
-    
-    CGEventPost(kCGSessionEventTap, e30); /// Not sure if order matters
+
+    DDLogDebug(@"TouchSimulator: Sending dockSwipe with phase %d with events: %@ %@", phase, e30ToPost, e29);
+
+    CGEventPost(kCGSessionEventTap, e30ToPost); /// Not sure if order matters
     CGEventPost(kCGSessionEventTap, e29);
     
     if (phase == kIOHIDEventPhaseBegan) {
@@ -281,7 +660,7 @@ static NSMutableDictionary *_swipeInfo;
         ///     Edit: We didn't release the events in MMF 3.0.0 Beta 6. I wonder why I didn't notice this? (Should leak a little bit of memory.) We then moved to using `__bridge_transfer`
         ///                 On 28.08.2024 we moved to using `__bridge` and simply calling `CFRelease()` afterwards. (That's the same as using `__bridge_transfer`, which I find confusing.)
 
-        NSDictionary *events = @{@"e30": (__bridge id)e30, @"e29": (__bridge id)e29};
+        NSDictionary *events = @{@"e30": (__bridge id)e30ToPost, @"e29": (__bridge id)e29};
         
         /// Dispatch to main queue
         /// Notes:
@@ -308,9 +687,14 @@ static NSMutableDictionary *_swipeInfo;
     ///
     /// Release events
     ///
-    
+
     CFRelease(e29);
     CFRelease(e30);
+    if (e30ToPost != e30) {
+        /// Release our owned augmented copy. If it was stored in the `events` dict above, that dict holds its own
+        /// retain, so it stays alive until the double/triple-send timers are invalidated.
+        CFRelease(e30ToPost);
+    }
     
     ///
     /// Update state

--- a/Notes/macOS27DockSwipe.md
+++ b/Notes/macOS27DockSwipe.md
@@ -1,0 +1,38 @@
+# macOS 27 Dock Swipe Compatibility
+
+## Context
+
+On macOS 27 beta, synthetic dock-swipe gestures stopped working when Mac Mouse Fix posted only the public `CGEvent` gesture fields. The affected user-facing actions are Spaces, Mission Control, App Expose, Show Desktop, and Launchpad-style dock swipes.
+
+The core approach is based on PR [#1895](https://github.com/noah-nuebling/mac-mouse-fix/pull/1895), which in turn references the reverse-engineering work around InstantSpaceSwitcher / FasterSwiper and the serialized `CGEvent` field `4205`.
+
+## Root Cause
+
+Dock no longer appears to treat the public synthetic gesture fields as sufficient input on macOS 27. It expects the raw IOKit HID gesture payload embedded in the serialized `CGEvent`. Without that payload, the event still posts, but Dock ignores it.
+
+The fix augments dock-swipe events by:
+
+- serializing the already-built `CGEvent`
+- parsing the private big-endian field format
+- inserting or replacing field `4205` with a raw HID payload
+- rebuilding the event with `CGEventCreateFromData()`
+
+## Multi-Display Handling
+
+On macOS 27, Dock also appears to associate an in-flight dock-swipe stream with the display implied by the raw HID position fields. For modified-drag gestures, the synthetic dock-swipe event is therefore anchored to the drag origin instead of the live cursor position.
+
+If the real pointer leaves the drag-origin display before button release, the current synthetic dock-swipe stream is ended once at the drag origin and then suppressed until the physical drag ends. This avoids continuing one gesture stream across two displays, which can leave Dock's gesture state stuck.
+
+For this cross-display termination, `Ended` is used instead of `Cancelled` because it matches a normal gesture lifecycle and allows Dock to settle the in-progress transition instead of rolling it back.
+
+## Validation
+
+Validated locally on macOS 27 with:
+
+- single-display modified drag to switch Spaces
+- dual-display modified drag, including moving the real cursor across displays mid-drag
+- repeated cross-display drags without losing subsequent modified-drag gestures
+- cursor visibility and position after release
+- scroll direction and other helper features after install
+
+The local validation build was signed with the same App/Helper entitlements as the working 3.0.8-based test build.

--- a/Shared/Animation/DisplayLink.m
+++ b/Shared/Animation/DisplayLink.m
@@ -203,8 +203,24 @@ NSString *MFCGDisplayChangeSummaryFlags_ToString(CGDisplayChangeSummaryFlags fla
                 return;
             }
             
-            CVDisplayLinkRelease(_displayLink);
+            if (_displayLink != NULL) {
+                CVDisplayLinkRelease(_displayLink);
+            }
             _displayLink = NULL; /// I'm pretty sure CVDisplayLinkCreateWithActiveCGDisplays() always overrides the `_displayLink` to be either NULL or valid. If it sometimes leaves the value untouched, then we'd have to set it to NULL after releasing to prevent use-after-free.
+        }
+
+        CVReturn activeDisplayRet = ret;
+        CVReturn activeDisplayCallbackRet = ret2;
+        CGDirectDisplayID fallbackDisplay = CGMainDisplayID();
+        ret = CVDisplayLinkCreateWithCGDisplay(fallbackDisplay, &_displayLink);
+        ret2 = _displayLink != NULL ? CVDisplayLinkSetOutputCallback(_displayLink, displayLinkCallback, (__bridge void *_Nullable)(self)) : kCVReturnInvalidArgument;
+        if ((ret == kCVReturnSuccess) && (ret2 == kCVReturnSuccess) && (_displayLink != NULL)) {
+            DDLogWarn(@"DisplayLink.m: (%@) Falling back to main-display CVDisplayLink (%@). Active-display codes: (%@, %@)", [self identifier], _displayLink, MFCVReturn_ToString(activeDisplayRet), MFCVReturn_ToString(activeDisplayCallbackRet));
+            return;
+        }
+        if (_displayLink != NULL) {
+            CVDisplayLinkRelease(_displayLink);
+            _displayLink = NULL;
         }
         
         mfabort(@"DisplayLink.m: (%@) Failed to create CVDisplayLink (%@) after %d tries. Last codes: (%@, %@)", [self identifier], _displayLink, max_tries, MFCVReturn_ToString(ret), MFCVReturn_ToString(ret2));


### PR DESCRIPTION
## Summary
- augment synthetic dock-swipe events on macOS 27 with the raw IOKit HID payload required by Dock
- anchor modified-drag dock-swipe events to the drag-origin display and end the synthetic stream when the real pointer crosses displays
- avoid stale delayed end-event replays on the macOS 27 augmented path
- add a main-display CVDisplayLink fallback for active-display link creation failures
- document root cause, source, multi-display behavior, and validation in `Notes/macOS27DockSwipe.md`

## Source / attribution
This builds on PR #1895 by @megyland:
https://github.com/noah-nuebling/mac-mouse-fix/pull/1895

That PR identified the macOS 27 dock-swipe breakage and the need to embed raw HID payload data in serialized `CGEvent` field `4205`, referencing the InstantSpaceSwitcher / FasterSwiper reverse-engineering work.

## Root cause
On macOS 27, Dock no longer appears to act on only the public synthetic `CGEvent` gesture fields for dock swipes. It expects the raw IOKit HID gesture payload inside the serialized event. For modified-drag gestures on multi-display setups, Dock also appears to tie the gesture stream to the payload position/display, so continuing one synthetic stream after the real cursor crosses displays can leave Dock's gesture state stuck.

## Validation
- `git diff --cached --check`
- `xcodebuild -project "/tmp/mac-mouse-fix/Mouse Fix.xcodeproj" -scheme "App - Release" -configuration Release -derivedDataPath "/tmp/MacMouseFix-pr-DerivedData" CODE_SIGNING_ALLOWED=NO build`
- local signed install tested on macOS 27:
  - single-display Spaces switching
  - dual-display drag with cursor crossing displays mid-drag
  - repeated cross-display drags without losing subsequent gestures
  - cursor visibility/position after release
  - scroll direction and other helper features
