### PR TITLE
Fix macOS 27 dock-swipes: prefer SLEventSetIOHIDEvent over hardcoded CGEvent offsets

### DIFF
--- a/Shared/IOKit/CGEventHIDEventBridge.m
+++ b/Shared/IOKit/CGEventHIDEventBridge.m
@@ -9,6 +9,7 @@
 
 #import "CGEventHIDEventBridge.h"
 @import CoreGraphics.CGEvent;
+#import <dlfcn.h>
 
 @implementation CGEventHIDEventBridge
 
@@ -35,9 +36,24 @@ void CGEventSetHIDEvent(CGEventRef cgEvent, HIDEvent *hidEvent) {
     return CGEventSetIOHIDEvent(cgEvent, (__bridge IOHIDEventRef)hidEvent);
 }
 
-/// Defining our own IOHIDEvent -> CGEvent function, because we can't link against `_SLEventSetIOHIDEvent`. (See header)
+/// IOHIDEvent -> CGEvent.
+///     We prefer Apple's own private `SLEventSetIOHIDEvent` (SkyLight), resolved at runtime via `dlsym`.
+///     We keep our hand-rolled offset-based writer below as a fallback.
+///
+///     Why: Our hand-rolled writer stores the `IOHIDEventRef` into the opaque `CGEvent`/`CGSEventRecord`
+///     struct using hardcoded offsets (`0x18` / `0xd0`). Those offsets are not part of any stable ABI, so a
+///     `CGEvent` layout change can make us write the pointer to the wrong address – the `IOHIDEvent` then
+///     never reaches Dock and gesture simulation silently breaks. This is what happened on macOS 27
+///     ("Golden Gate"): synthetic dock swipes (Switch Spaces, Mission Control, Show Desktop, Launchpad) stopped
+///     working. See issue #1919 (and #1871, #1873, #1892 …) and the exploration in `Tests/FixDockSwipes.m`,
+///     which concluded that `SLEventSetIOHIDEvent` is the working path there.
+///
+///     `SLEventSetIOHIDEvent` exists on older macOS too, so preferring it is backwards-compatible and needs no
+///     version gate. We resolve it with `dlsym` rather than link `SkyLight.framework` so there is no link-time
+///     dependency (safer for a potential Mac App Store variant) and we degrade gracefully to the offset writer
+///     if the symbol ever disappears.
 void CGEventSetIOHIDEvent(CGEventRef cgEvent, IOHIDEventRef iohidEvent) {
-    
+
     /// Validate
     if (!cgEvent) {
         assert(false);
@@ -47,18 +63,34 @@ void CGEventSetIOHIDEvent(CGEventRef cgEvent, IOHIDEventRef iohidEvent) {
         assert(false);
         return;
     }
-    
+
+    /// Preferred path: Apple's private SLEventSetIOHIDEvent (SkyLight)
+    static void (*sl_setIOHIDEvent)(CGEventRef, IOHIDEventRef) = NULL;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        void *skylight = dlopen("/System/Library/PrivateFrameworks/SkyLight.framework/SkyLight", RTLD_LAZY);
+        if (skylight != NULL) {
+            sl_setIOHIDEvent = (void (*)(CGEventRef, IOHIDEventRef))dlsym(skylight, "SLEventSetIOHIDEvent");
+        }
+    });
+    if (sl_setIOHIDEvent != NULL) {
+        sl_setIOHIDEvent(cgEvent, iohidEvent);
+        return;
+    }
+
+    /// Fallback: hand-rolled offset writer (original implementation)
+
     /// Retain
     ///     CFRelease(cgEvent) also releases the embedded IOHIDEventRef
     ///     Update: [Apr 2025] ... that means if we're replacing an existing IOHIDEventRef here it might get leaked.
     CFRetain(iohidEvent);
-    
+
     /// Get ptr
     void *resultHIDPtr = (void *)cgEvent;
     applyOffset(&resultHIDPtr, 0x18); /// Shift || Update: [Apr 2025] SLSIsEventMatchingSymbolicHotKey() disassembly might suggest that 0x18 points to a CGSEventRecord
     resultHIDPtr = *(void **)resultHIDPtr; /// Dereference
     applyOffset(&resultHIDPtr, 0xd0); /// Shift
-    
+
     /// Store IOHIDEvent
     *(IOHIDEventRef *)resultHIDPtr = iohidEvent; /// Store pointer to iohidEvent
 }


### PR DESCRIPTION
Fixes #1919 (and the same underlying breakage in #1871, #1873, #1892, #1878, #1891 …).

## Problem
On macOS 27 ("Golden Gate"), synthetic dock-swipe gestures stopped working — mapping a button to **Spaces & Mission Control** (Click and Drag) or **Desktop & Launchpad** (Click and Scroll) does nothing. Ordinary clicks and drag-to-scroll are unaffected.

## Root cause
`CGEventSetIOHIDEvent()` in `Shared/IOKit/CGEventHIDEventBridge.m` attaches the `IOHIDEvent` to the `CGEvent` by writing the pointer into the opaque `CGEvent`/`CGSEventRecord` struct at **hardcoded offsets** (`0x18` → deref → `0xd0`). Those offsets are not a stable ABI. When the layout shifts, the pointer lands at the wrong address, the `IOHIDEvent` never reaches Dock, and the swipe is silently ignored. macOS 27 now requires that real `IOHIDEvent` payload (public `CGEvent` gesture fields alone are no longer honored), so the mis-attached event does nothing.

This matches the conclusion in the repo's own `Tests/FixDockSwipes.m`:
> `SLEventSetIOHIDEvent(...)` … CG-variant (`CGEventSetIOHIDEvent`) doesn't work.

## Fix
Prefer Apple's own private **`SLEventSetIOHIDEvent`** (SkyLight), resolved at runtime via `dlsym`, and fall back to the hand-rolled offset writer only if the symbol can't be resolved.

- **Layout-independent** — no more hardcoded struct offsets on the primary path.
- **Backwards-compatible** — `SLEventSetIOHIDEvent` exists on older macOS too, so it's used everywhere; no `@available` gate needed.
- **`dlsym`, not link-time** — no build dependency on a private framework (safer for a Mac App Store variant), and it degrades gracefully to the offset writer if the symbol ever disappears.

Single-file change: `Shared/IOKit/CGEventHIDEventBridge.m`.

## Verification (macOS 27.0, build 26A5378j, Apple Silicon)
Because this environment only had Command Line Tools (no full Xcode to build the app), I verified the **mechanism** end-to-end out-of-process rather than by compiling the app:

- Built the exact `HIDEvent` that `TouchSimulator`'s macOS-27 path builds and posted it two ways. Attaching via `SLEventSetIOHIDEvent` **reliably switched Spaces** (confirmed programmatically via `CGSGetActiveSpace`, `405 → 234 → 146 …`); the old public-`CGEvent`-field method (shipped in 3.0.8) **never** switched.
- Confirmed the same path also drives **vertical (Mission Control)** and **pinch (Show Desktop / Launchpad)** gestures.
- As a real-world check, I ran a small active-`CGEventTap` shim that re-attaches an `IOHIDEvent` (via `SLEventSetIOHIDEvent`) to the dock-swipe events posted by an **installed, unmodified Mac Mouse Fix 3.0.8**, and all of its Button-4 dock-swipe actions started working again on macOS 27. That directly validates that `SLEventSetIOHIDEvent` is the correct attach path here.

I was not able to compile MMF itself, so I have **not** built this exact diff into the app — please build/test before merging.

## Prior art / attribution
Same core fix as #1912 and #1916 (both also swap to `SLEventSetIOHIDEvent` in `CGEventHIDEventBridge.m`); related work in #1895 and #1918. Opening this with the root-cause writeup and the build-`26A5378j` verification data above in case it's useful — happy to close in favor of whichever you prefer to merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)