### PR TITLE
Fix dock-swipe gestures broken on macOS 27 

### DIFF
--- a/Shared/IOKit/CGEventHIDEventBridge.h
+++ b/Shared/IOKit/CGEventHIDEventBridge.h
@@ -56,7 +56,9 @@ void CGEventSetHIDEvent(CGEventRef _Nonnull, HIDEvent * _Nonnull);
 
 /// Unsuccessful, we ended up writing our own function.
 /// Actually in `SkyLight.tbd` there is `_SLEventSetIOHIDEvent`, but I can't find a definition that we can link against.
-///     Update: [Jun 2026] If you just add `SkyLight.framework` to the project, the linker finds it ->  Could replace custom `CGEventSetHIDEvent` with `SLEventSetIOHIDEvent`, but it works fine.
+///     Update: [Jun 2026] If you just add `SkyLight.framework` to the project, the linker finds it -> Could replace custom `CGEventSetHIDEvent` with `SLEventSetIOHIDEvent`.
+///     Update: [Jul 2026] Did that - the offset-writer broke silently on macOS 27 since its hardcoded offsets aren't
+///         a stable ABI. See `CGEventSetIOHIDEvent()` in the .m file. Fixes #1871 and duplicates.
 
 /// Trying to find a function that converts HIDEvent -> CGEvent
 ///     (__bridge doesn't work)

--- a/Shared/IOKit/CGEventHIDEventBridge.m
+++ b/Shared/IOKit/CGEventHIDEventBridge.m
@@ -9,6 +9,9 @@
 
 #import "CGEventHIDEventBridge.h"
 @import CoreGraphics.CGEvent;
+#import <dispatch/dispatch.h>
+#import "Logging.h"
+#import "PrivateFunctions.h"
 
 @implementation CGEventHIDEventBridge
 
@@ -35,7 +38,9 @@ void CGEventSetHIDEvent(CGEventRef cgEvent, HIDEvent *hidEvent) {
     return CGEventSetIOHIDEvent(cgEvent, (__bridge IOHIDEventRef)hidEvent);
 }
 
-/// Defining our own IOHIDEvent -> CGEvent function, because we can't link against `_SLEventSetIOHIDEvent`. (See header)
+/// Update: [Jul 2026] The offset-writer below broke on macOS 27 - hardcoded struct offsets aren't a stable ABI.
+///     We now prefer Apple's own `SLEventSetIOHIDEvent` (via `MFLoadSymbol_native`), and only use the offset-writer
+///     as a fallback pre-macOS-27, where it was previously validated. Fixes #1871 and duplicates.
 void CGEventSetIOHIDEvent(CGEventRef cgEvent, IOHIDEventRef iohidEvent) {
     
     /// Validate
@@ -47,7 +52,32 @@ void CGEventSetIOHIDEvent(CGEventRef cgEvent, IOHIDEventRef iohidEvent) {
         assert(false);
         return;
     }
-    
+
+    /// Preferred path: Apple's own private `SLEventSetIOHIDEvent` (SkyLight)
+    static void (*slEventSetIOHIDEvent)(CGEventRef, IOHIDEventRef) = NULL;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        slEventSetIOHIDEvent = (void (*)(CGEventRef, IOHIDEventRef))MFLoadSymbol_native(kMFFrameworkSkyLight, @"SLEventSetIOHIDEvent");
+    });
+    if (slEventSetIOHIDEvent) {
+        /// Retain
+        ///     CFRelease(cgEvent) also releases the embedded IOHIDEventRef
+        ///     Update: [Apr 2025] ... that means if we're replacing an existing IOHIDEventRef here it might get leaked.
+        ///     Update: [Jul 2026] Also retaining here even though this is Apple's own setter - we don't know its
+        ///         retain contract, and an extra retain is much safer than an under-retain.
+        CFRetain(iohidEvent);
+        slEventSetIOHIDEvent(cgEvent, iohidEvent);
+        return;
+    }
+
+    /// Fallback: hand-rolled offset writer (original implementation)
+    ///     Update: [Jul 2026] These offsets are known-wrong on macOS 27+, so only use them pre-27, where they were
+    ///         previously validated. On 27+, skip instead of writing to a struct offset we already know is unsafe.
+    if (@available(macOS 27.0, *)) {
+        DDLogWarn("CGEventSetIOHIDEvent: couldn't resolve SLEventSetIOHIDEvent on macOS 27+, skipping instead of using the known-broken offset writer.");
+        return;
+    }
+
     /// Retain
     ///     CFRelease(cgEvent) also releases the embedded IOHIDEventRef
     ///     Update: [Apr 2025] ... that means if we're replacing an existing IOHIDEventRef here it might get leaked.


### PR DESCRIPTION
Fixes #1871 and the duplicates (#1873, #1878, #1887, #1891, #1892, #1919, ...).

## Problem

`CGEventSetIOHIDEvent()` attaches an IOHIDEvent to a CGEvent by poking the pointer into the opaque CGEvent/CGSEventRecord struct at hardcoded offsets (0x18 / 0xd0). Those offsets were never a stable ABI, and the struct layout shifted on macOS 27, so the pointer ends up at the wrong address and Dock never sees a real IOHIDEvent - which is why every synthetic dock-swipe gesture (Spaces, Mission Control, Show Desktop, Launchpad) silently stopped doing anything.

## Fix

Prefers Apple's own `SLEventSetIOHIDEvent`, resolved once via the project's existing `MFLoadSymbol_native(kMFFrameworkSkyLight, ...)` helper (`Shared/Utility/PrivateFunctions`). Falls back to the offset-writer only pre-macOS-27, where it was actually validated - on 27+ it's skipped instead of executed, since it's already known to be broken there.

## Notes

Same root cause and fix direction as #1920 / #1912 / #1916 (swap to `SLEventSetIOHIDEvent`). A couple of things that came up while testing, in case they're useful:

- Reuses the project's own `MFLoadSymbol_native` / `kMFFrameworkSkyLight` instead of hand-rolling a `dlsym` call.
- Also `CFRetain`s the `IOHIDEventRef` on the new path, matching what the old offset-writer already did - `SLEventSetIOHIDEvent`'s retain contract isn't documented anywhere, and `TouchSimulator.m` can repost some dock-swipe events up to 500ms later via a timer, so skipping the retain risks a use-after-free if the event isn't retained internally.
- The offset-writer fallback is skipped on macOS 27+ instead of always running, since the only current caller is gated to macOS 27+.

## Testing

Tested on macOS 27 - Spaces/Mission Control/Show Desktop click-and-drag all work again after this.