### PR TITLE
Fix macOS 27 dock swipes without release rebound

### DIFF
--- a/Helper/Core/Touch/TouchSimulator.m
+++ b/Helper/Core/Touch/TouchSimulator.m
@@ -186,10 +186,16 @@ static NSMutableDictionary *_swipeInfo;
     CGEventRef e30 = NULL;
     if (@available(macOS 27.0, *)) {
         
-        /// Un-flip the delta
+        /// Un-flip progress and velocity
         ///     The `d` input args are already pre-flipped by `ModifiedDrag.m` if `invertedFromDevice == true`. But the macOS 27 path applies the flipping by itself somehow.
-        double __dockSwipeOriginOffset = _dockSwipeOriginOffset;
-        if (invertedFromDevice) __dockSwipeOriginOffset *= -1; /// Could also apply the unflipping to the `d` argument above.
+        ///     Both values need to be in the same coordinate space. If only progress is un-flipped, the release
+        ///     velocity points backwards and causes a visible bounce/stutter at the end of the transition.
+        double unflippedOriginOffset = _dockSwipeOriginOffset;
+        double unflippedExitSpeed = exitSpeed;
+        if (invertedFromDevice) {
+            unflippedOriginOffset *= -1;
+            unflippedExitSpeed *= -1;
+        }
         
         /// Create HIDEvent
         ///     Note: Setting the timestamp to `mach_absolute_time()` here would make some sense but we're not setting timestamps anywhere else when simulating gestures
@@ -200,16 +206,16 @@ static NSMutableDictionary *_swipeInfo;
         [hidEvent setOptions: options];
         [hidEvent setIntegerValue: type                             forField: kIOHIDEventFieldDockSwipeMotion];
         [hidEvent setIntegerValue: kIOHIDGestureFlavorDockPrimary   forField: kIOHIDEventFieldDockSwipeFlavor];
-        [hidEvent setDoubleValue: __dockSwipeOriginOffset           forField: kIOHIDEventFieldDockSwipeProgress];
+        [hidEvent setDoubleValue: unflippedOriginOffset             forField: kIOHIDEventFieldDockSwipeProgress];
         
         /// Attach velocity event on exit
         if (phase == kIOHIDEventPhaseEnded || phase == kIOHIDEventPhaseCancelled) {
             
             HIDEvent *childEvent = [[HIDEvent alloc] initWithType: kIOHIDEventTypeVelocity timestamp: 0 senderID: 0];
             
-            [childEvent setDoubleValue: exitSpeed forField: kIOHIDEventFieldVelocityX];
-            [childEvent setDoubleValue: exitSpeed forField: kIOHIDEventFieldVelocityY];
-            [childEvent setDoubleValue: 0.0       forField: kIOHIDEventFieldVelocityZ];
+            [childEvent setDoubleValue: unflippedExitSpeed forField: kIOHIDEventFieldVelocityX];
+            [childEvent setDoubleValue: unflippedExitSpeed forField: kIOHIDEventFieldVelocityY];
+            [childEvent setDoubleValue: 0.0                forField: kIOHIDEventFieldVelocityZ];
             
             [hidEvent appendEvent: childEvent];
         }
@@ -376,4 +382,3 @@ static NSMutableDictionary *_swipeInfo;
 
 
 @end
-

--- a/Shared/IOKit/CGEventHIDEventBridge.h
+++ b/Shared/IOKit/CGEventHIDEventBridge.h
@@ -56,7 +56,9 @@ void CGEventSetHIDEvent(CGEventRef _Nonnull, HIDEvent * _Nonnull);
 
 /// Unsuccessful, we ended up writing our own function.
 /// Actually in `SkyLight.tbd` there is `_SLEventSetIOHIDEvent`, but I can't find a definition that we can link against.
-///     Update: [Jun 2026] If you just add `SkyLight.framework` to the project, the linker finds it ->  Could replace custom `CGEventSetHIDEvent` with `SLEventSetIOHIDEvent`, but it works fine.
+///     Update: [Jun 2026] If you just add `SkyLight.framework` to the project, the linker finds it.
+///     Update: [Jul 2026] The custom offset writer broke on macOS 27. We now load `SLEventSetIOHIDEvent` dynamically
+///         on macOS 27 and keep the old implementation only for earlier systems, where its offsets are known to work.
 
 /// Trying to find a function that converts HIDEvent -> CGEvent
 ///     (__bridge doesn't work)

--- a/Shared/IOKit/CGEventHIDEventBridge.m
+++ b/Shared/IOKit/CGEventHIDEventBridge.m
@@ -9,6 +9,9 @@
 
 #import "CGEventHIDEventBridge.h"
 @import CoreGraphics.CGEvent;
+#import <dispatch/dispatch.h>
+#import "Logging.h"
+#import "PrivateFunctions.h"
 
 @implementation CGEventHIDEventBridge
 
@@ -35,7 +38,9 @@ void CGEventSetHIDEvent(CGEventRef cgEvent, HIDEvent *hidEvent) {
     return CGEventSetIOHIDEvent(cgEvent, (__bridge IOHIDEventRef)hidEvent);
 }
 
-/// Defining our own IOHIDEvent -> CGEvent function, because we can't link against `_SLEventSetIOHIDEvent`. (See header)
+/// Attaches an IOHIDEvent to a CGEvent.
+///     The old implementation writes through hard-coded CGEvent struct offsets. Those offsets changed on macOS 27,
+///     so use SkyLight's setter there and keep the old implementation only for older macOS versions.
 void CGEventSetIOHIDEvent(CGEventRef cgEvent, IOHIDEventRef iohidEvent) {
     
     /// Validate
@@ -45,6 +50,27 @@ void CGEventSetIOHIDEvent(CGEventRef cgEvent, IOHIDEventRef iohidEvent) {
     }
     if (!iohidEvent) {
         assert(false);
+        return;
+    }
+
+    /// Use SkyLight's setter on macOS 27
+    ///     `SLEventSetIOHIDEvent` copies the HID payload into the CGEvent. It doesn't take an extra retain on the
+    ///     input object, so retaining here would leak one HIDEvent for every simulated gesture event.
+    if (@available(macOS 27.0, *)) {
+        typedef void (*SLEventSetIOHIDEventFunction)(CGEventRef, IOHIDEventRef);
+        static SLEventSetIOHIDEventFunction slEventSetIOHIDEvent = NULL;
+        static dispatch_once_t onceToken;
+        dispatch_once(&onceToken, ^{
+            slEventSetIOHIDEvent = (SLEventSetIOHIDEventFunction)MFLoadSymbol_native(kMFFrameworkSkyLight, @"SLEventSetIOHIDEvent");
+        });
+
+        if (slEventSetIOHIDEvent) {
+            slEventSetIOHIDEvent(cgEvent, iohidEvent);
+        } else {
+            /// The offsets below are known to be invalid on macOS 27. Failing closed avoids writing through an
+            /// unknown pointer if Apple ever removes or renames the private setter.
+            DDLogError("CGEventSetIOHIDEvent: Couldn't resolve SLEventSetIOHIDEvent on macOS 27. Skipping the known-incompatible offset writer.");
+        }
         return;
     }
     


### PR DESCRIPTION
## Summary

This fixes the macOS 27 Dock Swipe path used by Spaces, Mission Control, Show Desktop, Launchpad, and Move Between Spaces.

- Attach the `HIDEvent` with SkyLight's `SLEventSetIOHIDEvent` on macOS 27 instead of writing through hard-coded `CGEvent` offsets that changed in macOS 27.
- Fail closed if that symbol cannot be resolved, rather than writing through offsets already known to be incompatible.
- Keep the existing offset implementation unchanged on macOS 26 and earlier.
- Normalize both Dock Swipe progress and ending velocity when `invertedFromDevice` is set. Normalizing progress alone makes the release velocity point backward, which causes a visible bounce/stutter at the end of a transition.

Fixes #1871. Related reports include #1872, #1873, #1874, #1876, #1877, #1878, #1880, #1882, #1887, #1891, #1892, #1919, #1926, #1931, and #1935.

## Real-world validation through the open-source companion

Before preparing this upstream change, I built and released an open-source temporary companion using the same HID-payload repair:

- Repository: https://github.com/timmyagentic/mac-mouse-fix-macos-27-fix
- Current release: https://github.com/timmyagentic/mac-mouse-fix-macos-27-fix/releases/latest
- Recommended install or update:

```bash
npx --yes mmf27-dock-swipe-fix@latest install
```

The initial real-world validation for this upstream change was performed with companion v0.2.0; current users should install the latest release through the npm command above or the version-independent latest-release link.

This is not only a compile-time proposal. The companion restores the affected continuous gestures on a real macOS 27 installation with Mac Mouse Fix 3.1.0 Beta 1. Its first version exposed a small direction-dependent release rebound; testing showed that progress and exit velocity must be normalized together, which is why this PR includes the `TouchSimulator` change as well as the bridge fix.

As of July 18, the v0.2.0 app asset has 7 download events and the repository has 2 stars. It also received an independent positive response in #1931: https://github.com/noah-nuebling/mac-mouse-fix/issues/1931#issuecomment-5010956660

The companion also preserves the source timestamp and uses a user-interactive event-tap thread because it repairs events in a separate process. Those event-tap-specific measures are unnecessary in the native in-process implementation, so this PR only ports the parts that belong upstream.

## Validation

- Full Debug build succeeded with Xcode 26.6 on macOS 27.
- Universal build succeeded for both `arm64` and `x86_64`.
- Round-tripped a subtype-23 Dock Swipe payload through `SLEventSetIOHIDEvent` and `SLEventCopyIOHIDEvent` on native arm64 and under Rosetta.
- On both architectures, the copied payload survived release of the input object, had the expected type, and was a distinct object while the input retain-count delta remained zero. Therefore this path deliberately does **not** add the extra `CFRetain` used by some proposed implementations; doing so would leak a HID event for every simulated gesture event.

## Relation to existing PRs

This follows the same stable setter direction explored in #1912, #1916, #1920, and #1924. The additional pieces here come from testing the released companion in real gestures: verified setter ownership semantics, preserving the legacy path on older macOS versions, and keeping progress plus ending velocity in the same coordinate space to avoid release rebound.
