### PR TITLE
Fix Spaces & Mission Control click-and-drag on macOS 27

### DIFF
--- a/Helper/Core/Drag/ThreeFingerSwipe/ModifiedDragOutputThreeFingerSwipe.m
+++ b/Helper/Core/Drag/ThreeFingerSwipe/ModifiedDragOutputThreeFingerSwipe.m
@@ -11,7 +11,10 @@
 #import "CGSSpace.h"
 #import "TouchSimulator.h"
 @import Cocoa;
+@import QuartzCore;
 #import "PointerFreeze.h"
+#import "SymbolicHotKeys.h"
+#import "Config.h"
 #import "Mac_Mouse_Fix_Helper-Swift.h"
 
 @implementation ModifiedDragOutputThreeFingerSwipe
@@ -21,6 +24,69 @@
 static ModifiedDragState *_drag;
 
 static int16_t _nOfSpaces = 1;
+
+/// On macOS 27 (Golden Gate), the WindowServer drops synthetic dockSwipe gesture events
+/// (`CGXSenderCanSynthesizeEvents()` compares the sender PID against the WindowServer's – not
+/// bypassable through code signing, Accessibility, or attaching an IOHIDEvent). So instead of the
+/// smooth dockSwipe gesture we accumulate the drag and trigger SymbolicHotKeys at fixed thresholds.
+/// Trade-off: discrete jumps instead of following the pointer. See #1871 / PR #1875.
+static BOOL useSymbolicHotKeyFallback(void) {
+    if (@available(macOS 27.0, *)) return YES;
+    return NO;
+}
+
+static double _accumulatedDelta = 0;
+static double _smoothedVelocity = 0; /// EMA of drag speed along the usage axis (px/s)
+static CFTimeInterval _lastInputTime = 0;
+static CGSSymbolicHotKey _lastVerticalSHK = (CGSSymbolicHotKey)-1; /// SHK that opened the overlay; -1 = none / unknown
+static CFTimeInterval _lastVerticalPostTime = 0;
+static CFTimeInterval _lastHorizontalPostTime = 0;
+
+static double _thresholdHorizontal = 220.0; /// px per space-switch
+static double _thresholdVertical = 150.0; /// px to open/close Mission Control / App Exposé
+static const double _flickMinDistance = 50.0;
+static const double _flickMinVelocity = 600.0; /// px/s
+static const double _flickMaxIdleTime = 0.08; /// s – pause before release cancels flick
+static const double _verticalCooldown = 0.4; /// s between vertical SHK posts
+static const double _horizontalCooldown = 0.35; /// s between space-switches (≈ slide animation)
+
+/// On macOS 26+, Mission Control / App Exposé are rendered by WindowManager. While open, it owns
+/// onscreen windows at layers 1–19 (empirically on macOS 27.0). Readable without Screen Recording.
+static BOOL exposeOverlayIsOpen(void) {
+    NSArray *windows = CFBridgingRelease(CGWindowListCopyWindowInfo(kCGWindowListOptionOnScreenOnly, kCGNullWindowID));
+    for (NSDictionary *w in windows) {
+        if (![w[(__bridge NSString *)kCGWindowOwnerName] isEqualToString:@"WindowManager"]) continue;
+        int layer = [w[(__bridge NSString *)kCGWindowLayer] intValue];
+        if (1 <= layer && layer <= 19) return YES;
+    }
+    return NO;
+}
+
+/// Open or close Mission Control / App Exposé. Returns whether an SHK was posted.
+static BOOL triggerVerticalSHK(BOOL draggedUp, CFTimeInterval now) {
+    
+    if (!exposeOverlayIsOpen()) {
+        CGSSymbolicHotKey shk = draggedUp ? kCGSHotKeyExposeAllWindows : kCGSHotKeyExposeApplicationWindows;
+        [SymbolicHotKeys post:shk];
+        _lastVerticalSHK = shk;
+        _lastVerticalPostTime = now;
+        return YES;
+    }
+    
+    /// Overlay is open – the opener SHK toggles it closed. Closing only in the natural direction
+    /// (down closes Mission Control, up closes App Exposé), like the real gesture.
+    CGSSymbolicHotKey opener = _lastVerticalSHK;
+    if (opener == (CGSSymbolicHotKey)-1) {
+        opener = draggedUp ? kCGSHotKeyExposeApplicationWindows : kCGSHotKeyExposeAllWindows;
+    }
+    BOOL closes = (opener == kCGSHotKeyExposeAllWindows) ? !draggedUp : draggedUp;
+    if (!closes) return NO;
+    
+    [SymbolicHotKeys post:opener];
+    _lastVerticalSHK = (CGSSymbolicHotKey)-1;
+    _lastVerticalPostTime = now;
+    return YES;
+}
 
 /// Interface funcs
 
@@ -32,11 +98,27 @@ static int16_t _nOfSpaces = 1;
     /// Get number of spaces
     ///     for use in `handleMouseInputWhileInUse()`. Getting it here for performance reasons. Not sure if significant.
     CFArrayRef spaces = CGSCopySpaces(CGSMainConnectionID(), CGSSpaceIncludesUser | CGSSpaceIncludesOthers | CGSSpaceIncludesCurrent);
-    /// Full screen spaces appear twice for some reason so we need to filter duplicates
-    NSSet *uniqueSpaces = [NSSet setWithArray:(__bridge NSArray *)spaces];
-    _nOfSpaces = uniqueSpaces.count;
+    if (spaces != NULL) {
+        /// Full screen spaces appear twice for some reason so we need to filter duplicates
+        NSSet *uniqueSpaces = [NSSet setWithArray:(__bridge NSArray *)spaces];
+        _nOfSpaces = MAX((int16_t)1, (int16_t)uniqueSpaces.count);
+        CFRelease(spaces);
+    } else {
+        _nOfSpaces = 1;
+    }
     
-    CFRelease(spaces);
+    /// Reset state for the symbolic-hotkey fallback
+    /// Note: `_lastVerticalSHK` / `_lastVerticalPostTime` are deliberately NOT reset – a follow-up drag
+    /// should be able to close Mission Control, and the vertical cooldown guards mid-animation re-fires.
+    _accumulatedDelta = 0;
+    _smoothedVelocity = 0;
+    _lastInputTime = CACurrentMediaTime();
+    _lastHorizontalPostTime = 0; /// Per-drag: rapid successive flicks can hop multiple spaces
+    
+    NSNumber *configThresholdH = (NSNumber *)config(@"Other.threeFingerSwipeSHKThresholdHorizontal");
+    NSNumber *configThresholdV = (NSNumber *)config(@"Other.threeFingerSwipeSHKThresholdVertical");
+    _thresholdHorizontal = [configThresholdH isKindOfClass:NSNumber.class] && configThresholdH.doubleValue > 0 ? configThresholdH.doubleValue : 220.0;
+    _thresholdVertical = [configThresholdV isKindOfClass:NSNumber.class] && configThresholdV.doubleValue > 0 ? configThresholdV.doubleValue : 150.0;
     
     /// Freeze pointer
     if (GeneralConfig.freezePointerDuringModifiedDrag) {
@@ -46,11 +128,44 @@ static int16_t _nOfSpaces = 1;
 
 + (void)handleMouseInputWhileInUseWithDeltaX:(double)deltaX deltaY:(double)deltaY event:(CGEventRef)event {
     
+    if (useSymbolicHotKeyFallback()) {
+        /// Deltas are already inverted for `naturalDirection` by ModifiedDrag before they reach this plugin.
+        
+        CFTimeInterval now = CACurrentMediaTime();
+        CFTimeInterval dt = now - _lastInputTime;
+        _lastInputTime = now;
+        double axisDelta = (_drag->usageAxis == kMFAxisHorizontal) ? deltaX : deltaY;
+        if (dt > 0 && dt < 0.5) {
+            _smoothedVelocity = 0.7 * _smoothedVelocity + 0.3 * (axisDelta / dt);
+        }
+        
+        if (_drag->usageAxis == kMFAxisHorizontal) {
+            if ((now - _lastHorizontalPostTime) < _horizontalCooldown) {
+                _accumulatedDelta = 0; /// Discard motion during cooldown – one hard swipe = one space
+            } else {
+                _accumulatedDelta += deltaX;
+                if (fabs(_accumulatedDelta) >= _thresholdHorizontal) {
+                    /// Drag right -> previous space (matches natural-direction dockSwipe)
+                    [SymbolicHotKeys post:(_accumulatedDelta > 0 ? kCGSHotKeySpaceLeft : kCGSHotKeySpaceRight)];
+                    _accumulatedDelta = 0;
+                    _lastHorizontalPostTime = now;
+                }
+            }
+        } else if (_drag->usageAxis == kMFAxisVertical) {
+            _accumulatedDelta += deltaY;
+            if ((now - _lastVerticalPostTime) >= _verticalCooldown && fabs(_accumulatedDelta) >= _thresholdVertical) {
+                triggerVerticalSHK(_accumulatedDelta < 0, now);
+                _accumulatedDelta = 0;
+            }
+        }
+        return;
+    }
+    
     /**
-     Horizontal dockSwipe scaling
-     This makes horizontal dockSwipes (switch between spaces) follow the pointer exactly
-     I arrived at these value through testing documented in the NotePlan note "MMF - Scraps - Testing DockSwipe scaling"
-     TODO: Test this on a vertical screen
+    Horizontal dockSwipe scaling
+    This makes horizontal dockSwipes (switch between spaces) follow the pointer exactly
+    I arrived at these value through testing documented in the NotePlan note "MMF - Scraps - Testing DockSwipe scaling"
+    TODO: Test this on a vertical screen
      */
     CGSize screenSize = NSScreen.mainScreen.frame.size;
     double originOffsetForOneSpace = _nOfSpaces == 1 ? 2.0 : 1.0 + (1.0 / (_nOfSpaces-1));
@@ -77,6 +192,35 @@ static int16_t _nOfSpaces = 1;
 }
 
 + (void)handleDeactivationWhileInUseWithCancel:(BOOL)cancel {
+    
+    if (useSymbolicHotKeyFallback()) {
+        
+        CFTimeInterval now = CACurrentMediaTime();
+        BOOL stillMoving = (now - _lastInputTime) <= _flickMaxIdleTime;
+        if (!cancel
+            && stillMoving
+            && fabs(_accumulatedDelta) >= _flickMinDistance
+            && fabs(_smoothedVelocity) >= _flickMinVelocity
+            && (_smoothedVelocity > 0) == (_accumulatedDelta > 0)) {
+            
+            if (_drag->usageAxis == kMFAxisHorizontal) {
+                if ((now - _lastHorizontalPostTime) >= _horizontalCooldown) {
+                    [SymbolicHotKeys post:(_accumulatedDelta > 0 ? kCGSHotKeySpaceLeft : kCGSHotKeySpaceRight)];
+                    _lastHorizontalPostTime = now;
+                }
+            } else if (_drag->usageAxis == kMFAxisVertical) {
+                if ((now - _lastVerticalPostTime) >= _verticalCooldown) {
+                    triggerVerticalSHK(_accumulatedDelta < 0, now);
+                }
+            }
+        }
+        _accumulatedDelta = 0;
+        
+        if (GeneralConfig.freezePointerDuringModifiedDrag) {
+            [PointerFreeze unfreeze];
+        }
+        return;
+    }
     
     MFDockSwipeType type;
     IOHIDEventPhaseBits phase;

--- a/Helper/Core/Touch/TouchSimulator.m
+++ b/Helper/Core/Touch/TouchSimulator.m
@@ -96,6 +96,8 @@ static NSMutableDictionary *_swipeInfo;
 + (void)postDockSwipeEventWithDelta:(double)d type:(MFDockSwipeType)type phase:(IOHIDEventPhaseBits)phase invertedFromDevice:(BOOL)invertedFromDevice {
     
     /// macOS 27 fix notes: (CGEventFields are now ignored, instead it relies on an IOHIDEvent) (See exploration in FixDockSwipes.m)
+    ///     Update: [Jul 2026] Attaching the IOHIDEvent must go through `SLEventSetIOHIDEvent` – the hardcoded CGEvent
+    ///         offsets in `CGEventSetIOHIDEvent` broke when the struct layout shifted. See CGEventHIDEventBridge.m.
     ///     Problems/TODOs: (macOS 27 Beta 2)
     ///         - Dock swipe transitions sometimes get stuck and you can't unstick it with the same dock-swipe – this is pretty bad! macOS should fix this but it doesn't happen with a Trackpad.
     ///         - (Translation issue) `scroll-effect.4-pinch.hint` confuses scrolling up and scrolling down. (At least under the default `naturalScrolling = 1` setting) (Putting this note into TouchSimulator.m because we made so many changes to translations on non-master branch.)
@@ -186,10 +188,16 @@ static NSMutableDictionary *_swipeInfo;
     CGEventRef e30 = NULL;
     if (@available(macOS 27.0, *)) {
         
-        /// Un-flip the delta
+        /// Un-flip progress and velocity
         ///     The `d` input args are already pre-flipped by `ModifiedDrag.m` if `invertedFromDevice == true`. But the macOS 27 path applies the flipping by itself somehow.
-        double __dockSwipeOriginOffset = _dockSwipeOriginOffset;
-        if (invertedFromDevice) __dockSwipeOriginOffset *= -1; /// Could also apply the unflipping to the `d` argument above.
+        ///     Both values need to be in the same coordinate space. If only progress is un-flipped, the release
+        ///     velocity points backwards and causes a visible bounce/stutter at the end of the transition.
+        double unflippedOriginOffset = _dockSwipeOriginOffset;
+        double unflippedExitSpeed = exitSpeed;
+        if (invertedFromDevice) {
+            unflippedOriginOffset *= -1;
+            unflippedExitSpeed *= -1;
+        }
         
         /// Create HIDEvent
         ///     Note: Setting the timestamp to `mach_absolute_time()` here would make some sense but we're not setting timestamps anywhere else when simulating gestures
@@ -200,16 +208,16 @@ static NSMutableDictionary *_swipeInfo;
         [hidEvent setOptions: options];
         [hidEvent setIntegerValue: type                             forField: kIOHIDEventFieldDockSwipeMotion];
         [hidEvent setIntegerValue: kIOHIDGestureFlavorDockPrimary   forField: kIOHIDEventFieldDockSwipeFlavor];
-        [hidEvent setDoubleValue: __dockSwipeOriginOffset           forField: kIOHIDEventFieldDockSwipeProgress];
+        [hidEvent setDoubleValue: unflippedOriginOffset             forField: kIOHIDEventFieldDockSwipeProgress];
         
         /// Attach velocity event on exit
         if (phase == kIOHIDEventPhaseEnded || phase == kIOHIDEventPhaseCancelled) {
             
             HIDEvent *childEvent = [[HIDEvent alloc] initWithType: kIOHIDEventTypeVelocity timestamp: 0 senderID: 0];
             
-            [childEvent setDoubleValue: exitSpeed forField: kIOHIDEventFieldVelocityX];
-            [childEvent setDoubleValue: exitSpeed forField: kIOHIDEventFieldVelocityY];
-            [childEvent setDoubleValue: 0.0       forField: kIOHIDEventFieldVelocityZ];
+            [childEvent setDoubleValue: unflippedExitSpeed forField: kIOHIDEventFieldVelocityX];
+            [childEvent setDoubleValue: unflippedExitSpeed forField: kIOHIDEventFieldVelocityY];
+            [childEvent setDoubleValue: 0.0                forField: kIOHIDEventFieldVelocityZ];
             
             [hidEvent appendEvent: childEvent];
         }

--- a/Shared/IOKit/CGEventHIDEventBridge.h
+++ b/Shared/IOKit/CGEventHIDEventBridge.h
@@ -56,7 +56,9 @@ void CGEventSetHIDEvent(CGEventRef _Nonnull, HIDEvent * _Nonnull);
 
 /// Unsuccessful, we ended up writing our own function.
 /// Actually in `SkyLight.tbd` there is `_SLEventSetIOHIDEvent`, but I can't find a definition that we can link against.
-///     Update: [Jun 2026] If you just add `SkyLight.framework` to the project, the linker finds it ->  Could replace custom `CGEventSetHIDEvent` with `SLEventSetIOHIDEvent`, but it works fine.
+///     Update: [Jun 2026] If you just add `SkyLight.framework` to the project, the linker finds it.
+///     Update: [Jul 2026] The custom offset writer broke on macOS 27. We now load `SLEventSetIOHIDEvent` dynamically
+///         on macOS 27 and keep the old implementation only for earlier systems, where its offsets are known to work.
 
 /// Trying to find a function that converts HIDEvent -> CGEvent
 ///     (__bridge doesn't work)

--- a/Shared/IOKit/CGEventHIDEventBridge.m
+++ b/Shared/IOKit/CGEventHIDEventBridge.m
@@ -9,6 +9,8 @@
 
 #import "CGEventHIDEventBridge.h"
 @import CoreGraphics.CGEvent;
+#import "Logging.h"
+#import "PrivateFunctions.h"
 
 @implementation CGEventHIDEventBridge
 
@@ -35,7 +37,9 @@ void CGEventSetHIDEvent(CGEventRef cgEvent, HIDEvent *hidEvent) {
     return CGEventSetIOHIDEvent(cgEvent, (__bridge IOHIDEventRef)hidEvent);
 }
 
-/// Defining our own IOHIDEvent -> CGEvent function, because we can't link against `_SLEventSetIOHIDEvent`. (See header)
+/// Attaches an IOHIDEvent to a CGEvent.
+/// The old implementation writes through hard-coded CGEvent struct offsets. Those offsets changed on macOS 27,
+/// so use SkyLight's setter there and keep the old implementation only for older macOS versions.
 void CGEventSetIOHIDEvent(CGEventRef cgEvent, IOHIDEventRef iohidEvent) {
     
     /// Validate
@@ -45,6 +49,27 @@ void CGEventSetIOHIDEvent(CGEventRef cgEvent, IOHIDEventRef iohidEvent) {
     }
     if (!iohidEvent) {
         assert(false);
+        return;
+    }
+    
+    /// Use SkyLight's setter on macOS 27
+    /// `SLEventSetIOHIDEvent` copies the HID payload into the CGEvent. It doesn't take an extra retain on the
+    /// input object, so retaining here would leak one HIDEvent for every simulated gesture event.
+    if (@available(macOS 27.0, *)) {
+        typedef void (*SLEventSetIOHIDEventFunction)(CGEventRef, IOHIDEventRef);
+        static SLEventSetIOHIDEventFunction slEventSetIOHIDEvent = NULL;
+        static dispatch_once_t onceToken;
+        dispatch_once(&onceToken, ^{
+            slEventSetIOHIDEvent = (SLEventSetIOHIDEventFunction)MFLoadSymbol_native(kMFFrameworkSkyLight, @"SLEventSetIOHIDEvent");
+        });
+        
+        if (slEventSetIOHIDEvent) {
+            slEventSetIOHIDEvent(cgEvent, iohidEvent);
+        } else {
+            /// The offsets below are known to be invalid on macOS 27. Failing closed avoids writing through an
+            /// unknown pointer if Apple ever removes or renames the private setter.
+            DDLogError("CGEventSetIOHIDEvent: Couldn't resolve SLEventSetIOHIDEvent on macOS 27. Skipping the known-incompatible offset writer.");
+        }
         return;
     }
     


### PR DESCRIPTION
## Summary
- On macOS 27 (Golden Gate), WindowServer drops synthetic dockSwipe events, so Spaces & Mission Control click-and-drag now falls back to SymbolicHotKeys (discrete space / Mission Control / App Exposé triggers) for the `threeFingerSwipe` path. Fixes #1871.
- Attach DockSwipe `IOHIDEvent`s via SkyLight’s `SLEventSetIOHIDEvent` instead of hardcoded CGEvent offsets (layout shifted on 27), and unflip exit velocity together with progress to avoid release rebound for remaining dockSwipe callers (e.g. Scroll).

## Test plan
- [ ] On macOS 27, map a mouse button to Click and Drag → Spaces & Mission Control
- [ ] Hold and drag left/right ~220px → switches one Space; sustained drag chains with cooldown
- [ ] Hold and drag up/down ~150px → opens Mission Control / App Exposé; reverse drag closes
- [ ] Confirm Scroll & Navigate click-and-drag still works
- [ ] On macOS ≤ 26, confirm Spaces & Mission Control still uses the smooth dockSwipe path


Made with [Cursor](https://cursor.com)