### PR TITLE
Add "None" button action — captures the click without doing anything

### DIFF
--- a/App/UI/Main/Tabs/ButtonTab/RemapTable/RemapTableTranslator.m
+++ b/App/UI/Main/Tabs/ButtonTab/RemapTable/RemapTableTranslator.m
@@ -143,8 +143,16 @@ static NSArray *getOneShotEffectsTable(NSDictionary *rowDict) {
 //    MFMouseButtonNumber buttonNumber = ((NSNumber *)rowDict[kMFRemapsKeyTrigger][kMFButtonTriggerKeyButtonNumber]).unsignedIntValue;
     
     NSDictionary *selectedEffect = rowDict[kMFRemapsKeyEffect];
-    
+
     NSMutableArray *oneShotEffectsTable = @[
+        @{
+            @"ui": MFLocalizedString(@"effect.none", @""),
+            @"tool": MFLocalizedString(@"effect.none.hint", @""),
+            @"dict": @{
+              kMFActionDictKeyType: kMFActionDictTypeNone,
+            }
+        },
+        separatorEffectsTableEntry(),
         @{
             @"ui": MFLocalizedString(
                 @"effect.look-up",

--- a/App/UI/Main/Tabs/ButtonTab/RemapTable/RemapTableTranslator.m
+++ b/App/UI/Main/Tabs/ButtonTab/RemapTable/RemapTableTranslator.m
@@ -146,14 +146,6 @@ static NSArray *getOneShotEffectsTable(NSDictionary *rowDict) {
 
     NSMutableArray *oneShotEffectsTable = @[
         @{
-            @"ui": MFLocalizedString(@"effect.none", @""),
-            @"tool": MFLocalizedString(@"effect.none.hint", @""),
-            @"dict": @{
-              kMFActionDictKeyType: kMFActionDictTypeNone,
-            }
-        },
-        separatorEffectsTableEntry(),
-        @{
             @"ui": MFLocalizedString(
                 @"effect.look-up",
                 @""
@@ -177,6 +169,14 @@ static NSArray *getOneShotEffectsTable(NSDictionary *rowDict) {
             @"tool": MFLocalizedString(@"effect.smart-zoom.hint", @""),
             @"dict": @{
               kMFActionDictKeyType: kMFActionDictTypeSmartZoom,
+            }
+        },
+        @{
+            @"ui": MFLocalizedString(@"effect.none", @""),
+            @"tool": MFLocalizedString(@"effect.none.hint", @""),
+            @"hideable": @YES,
+            @"dict": @{
+              kMFActionDictKeyType: kMFActionDictTypeNone,
             }
         },
         @{

--- a/Helper/Core/Actions/Actions.m
+++ b/Helper/Core/Actions/Actions.m
@@ -178,7 +178,15 @@
             /// All that the main app has to do with the payload in order to make it a valid entry of the remap table's
             ///  dataModel is to add the kMFRemapsKeyEffect key and corresponding values
             [Remap sendAddModeFeedback:payload];
-            
+
+        } else if ([actionType isEqualToString:kMFActionDictTypeNone]) {
+
+            /// Intentionally do nothing.
+            ///     The button trigger still got captured (that's decided upstream in `Buttons.handleInput()`,
+            ///     based on whether *any* actionDict - including this one - exists for the button+level+duration,
+            ///     not on whether that actionDict does anything) - this branch just makes sure we don't accidentally
+            ///     fall into some other branch/behavior for the `none` type as the code evolves.
+
         }
     }
 }

--- a/Localization/Localizable.xcstrings
+++ b/Localization/Localizable.xcstrings
@@ -6934,6 +6934,28 @@
         }
       }
     },
+    "effect.none" : {
+      "comment" : "Name of a Button action that captures/consumes the button click (so the OS or the frontmost app never sees it) but otherwise does nothing. Useful for disabling an unwanted button.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "None"
+          }
+        }
+      }
+    },
+    "effect.none.hint" : {
+      "comment" : "",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disables the button.\n \nThe click is captured so nothing happens - it won't be passed through to the app you're using."
+          }
+        }
+      }
+    },
     "effect.smart-zoom" : {
       "comment" : "",
       "localizations" : {

--- a/Shared/Constants.h
+++ b/Shared/Constants.h
@@ -186,6 +186,8 @@ typedef NSString*                                                       MFString
 #define kMFActionDictTypeSystemDefinedEvent                             @"systemDefinedEvent"
 #define kMFActionDictTypeMouseButtonClicks                              @"mouseButton"
 #define kMFActionDictTypeAddModeFeedback                                @"addModeAction"
+// `none` - Captures/consumes the button trigger (so the OS/app never sees the click) but performs no effect. Lets users "disable" a button/click-level instead of leaving it unmapped (unmapped triggers are passed through untouched, see `Buttons.handleInput()`).
+#define kMFActionDictTypeNone                                           @"none"
 
 // Variant keys
 


### PR DESCRIPTION
Adds a new action type (kMFActionDictTypeNone) selectable from the Buttons tab's effect picker as "None". Unlike leaving a button/click- level unmapped (which passes the click through untouched, see Buttons.handleInput()'s maxClickLevel==0 check), selecting "None" still registers as a real entry in the remaps table — so the click gets captured/consumed like any other mapped action — but Actions.executeActionArray does nothing for it. Useful for disabling an unwanted button/click-level (e.g. an accidental side button) without it falling through to the OS/app's default behavior.

Only touches: a new constant, one new effectsTable entry (reuses all existing generic menu-building/selection code, no other UI changes needed), an explicit no-op branch in Actions.m for clarity, and new English-only localization strings (not translated into other languages yet).