### PR TITLE
Add "None" button action to fully disable a button/click-level

### DIFF
--- a/App/UI/Main/Tabs/ButtonTab/RemapTable/RemapTableTranslator.m
+++ b/App/UI/Main/Tabs/ButtonTab/RemapTable/RemapTableTranslator.m
@@ -143,8 +143,16 @@ static NSArray *getOneShotEffectsTable(NSDictionary *rowDict) {
 //    MFMouseButtonNumber buttonNumber = ((NSNumber *)rowDict[kMFRemapsKeyTrigger][kMFButtonTriggerKeyButtonNumber]).unsignedIntValue;
     
     NSDictionary *selectedEffect = rowDict[kMFRemapsKeyEffect];
-    
+
     NSMutableArray *oneShotEffectsTable = @[
+        @{
+            @"ui": MFLocalizedString(@"effect.none", @""),
+            @"tool": MFLocalizedString(@"effect.none.hint", @""),
+            @"dict": @{
+              kMFActionDictKeyType: kMFActionDictTypeNone,
+            }
+        },
+        separatorEffectsTableEntry(),
         @{
             @"ui": MFLocalizedString(
                 @"effect.look-up",

--- a/App/UI/Main/Tabs/ButtonTab/RemapTable/RemapTableTranslator.m
+++ b/App/UI/Main/Tabs/ButtonTab/RemapTable/RemapTableTranslator.m
@@ -146,14 +146,6 @@ static NSArray *getOneShotEffectsTable(NSDictionary *rowDict) {
 
     NSMutableArray *oneShotEffectsTable = @[
         @{
-            @"ui": MFLocalizedString(@"effect.none", @""),
-            @"tool": MFLocalizedString(@"effect.none.hint", @""),
-            @"dict": @{
-              kMFActionDictKeyType: kMFActionDictTypeNone,
-            }
-        },
-        separatorEffectsTableEntry(),
-        @{
             @"ui": MFLocalizedString(
                 @"effect.look-up",
                 @""
@@ -177,6 +169,14 @@ static NSArray *getOneShotEffectsTable(NSDictionary *rowDict) {
             @"tool": MFLocalizedString(@"effect.smart-zoom.hint", @""),
             @"dict": @{
               kMFActionDictKeyType: kMFActionDictTypeSmartZoom,
+            }
+        },
+        @{
+            @"ui": MFLocalizedString(@"effect.none", @""),
+            @"tool": MFLocalizedString(@"effect.none.hint", @""),
+            @"hideable": @YES,
+            @"dict": @{
+              kMFActionDictKeyType: kMFActionDictTypeNone,
             }
         },
         @{

--- a/Helper/Core/Actions/Actions.m
+++ b/Helper/Core/Actions/Actions.m
@@ -178,7 +178,15 @@
             /// All that the main app has to do with the payload in order to make it a valid entry of the remap table's
             ///  dataModel is to add the kMFRemapsKeyEffect key and corresponding values
             [Remap sendAddModeFeedback:payload];
-            
+
+        } else if ([actionType isEqualToString:kMFActionDictTypeNone]) {
+
+            /// Intentionally do nothing.
+            ///     The button trigger still got captured (that's decided upstream in `Buttons.handleInput()`,
+            ///     based on whether *any* actionDict - including this one - exists for the button+level+duration,
+            ///     not on whether that actionDict does anything) - this branch just makes sure we don't accidentally
+            ///     fall into some other branch/behavior for the `none` type as the code evolves.
+
         }
     }
 }

--- a/Localization/Localizable.xcstrings
+++ b/Localization/Localizable.xcstrings
@@ -6934,6 +6934,28 @@
         }
       }
     },
+    "effect.none" : {
+      "comment" : "Name of a Button action that captures/consumes the button click (so the OS or the frontmost app never sees it) but otherwise does nothing. Useful for disabling an unwanted button.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "None"
+          }
+        }
+      }
+    },
+    "effect.none.hint" : {
+      "comment" : "",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disables the button.\n \nThe click is captured so nothing happens - it won't be passed through to the app you're using."
+          }
+        }
+      }
+    },
     "effect.smart-zoom" : {
       "comment" : "",
       "localizations" : {

--- a/Shared/Constants.h
+++ b/Shared/Constants.h
@@ -186,6 +186,8 @@ typedef NSString*                                                       MFString
 #define kMFActionDictTypeSystemDefinedEvent                             @"systemDefinedEvent"
 #define kMFActionDictTypeMouseButtonClicks                              @"mouseButton"
 #define kMFActionDictTypeAddModeFeedback                                @"addModeAction"
+// `none` - Captures/consumes the button trigger (so the OS/app never sees the click) but performs no effect. Lets users "disable" a button/click-level instead of leaving it unmapped (unmapped triggers are passed through untouched, see `Buttons.handleInput()`).
+#define kMFActionDictTypeNone                                           @"none"
 
 // Variant keys
 


### PR DESCRIPTION
## Summary

Adds a `None` action to the Buttons tab that captures/consumes a button click (so it never reaches the OS or the frontmost app) but doesn't perform any effect - essentially lets you fully disable a specific mouse button/click-level.

## Motivation

I use a side mouse button (Mouse Button 5) as push-to-talk in TeamSpeak, which reads the raw HID input at a lower level, independent of Mac Mouse Fix. The problem: with no Mac Mouse Fix mapping at all on that button, it still triggers the OS/browser's default "Forward" navigation, since an unmapped button/click-level is passed straight through (see `Buttons.handleInput()`'s `maxClickLevel == 0` passthrough check). I wanted a way to keep using the button for push-to-talk in apps that read it directly, while stopping it from also triggering Back/Forward (or whatever else) everywhere else.

I imagine other people binding a button to something outside MMF (game binds, PTT, etc.) could run into the same issue, so this seemed worth a real feature rather than a personal patch.

## What changed

- New `kMFActionDictTypeNone` action type (`Shared/Constants.h`).
- New "None" entry in the Buttons tab's effect picker (`RemapTableTranslator.m`), hidden behind Option the same way Primary/Secondary Click are (`hideable: YES`), doesn't add clutter to the default menu.
- Explicit, documented no-op branch for it in `Actions.m`, the button still gets captured (that's decided upstream, based on whether *any* action exists for the button+level, not on what the action actually does), it just doesn't do anything.
- English-only localization strings for the new menu entry, haven't touched other languages.

## Testing

Built and ran locally (signed with my own personal Apple ID/team). Confirmed:
- Holding Option in the effect picker reveals "None" right before "Primary Click".
- Assigning it to a button captures the click (nothing reaches the OS/frontmost app) with no visible effect.

Happy to adjust naming/placement/wording if you'd prefer it done differently - wanted to get the underlying mechanism right first. Would appreciate a merge so I don't have to maintain a fork just for this.

## Note

Full disclosure: I'm not a Swift/Obj-C developer day-to-day, so this was written with AI assistance (vibe-coded). I read through the existing code paths carefully to match the codebase's own patterns (the `hideable` menu mechanism, the `maxClickLevel` passthrough logic, etc.) rather than just bolting something on, and it looks correct and works as expected in my testing, but flagging this so you can review with that in mind.